### PR TITLE
Implement profunctor prisms and laws

### DIFF
--- a/src/examples/prisms-example.ts
+++ b/src/examples/prisms-example.ts
@@ -1,0 +1,94 @@
+/**
+ * Developer Demo:
+ * - This file is not part of the library build.
+ * - Do not import it from 'src/index.ts' or 'src/types/index.ts'.
+ */
+
+// prisms-example.ts
+import {
+  Either, Left, Right, Option, Some, None,
+  Prism, preview, review, over, checkPrismLaws,
+  rightPrism, leftPrism, numberStringPrism
+} from "../types/catkit-prisms.js";
+
+console.log("🎯 Profunctor Prisms Demo");
+console.log("=========================\n");
+
+console.log("📊 What we're demonstrating:");
+console.log("• Profunctor prisms with Choice dictionaries (Function, Forget, Tagged)");
+console.log("• Generic prism constructor: prism(build, match)");
+console.log("• Interpreters: preview (Forget), review (Tagged), over (Function)");
+console.log("• Automatic law checking: build-match, preview-review, miss-no-op, composition fusion");
+console.log();
+
+// Example 1: Right prism on Either<string, number>
+console.log("🔍 Example 1: Right Prism");
+console.log("==========================");
+const prR = rightPrism<string, number, number>();
+
+const sHit: Either<string, number>  = Right(7);
+const sMiss: Either<string, number> = Left("err");
+
+console.log("Original Hit:", sHit);
+console.log("Original Miss:", sMiss);
+console.log("[Right prism] preview Hit:", preview(prR as any, sHit));
+console.log("[Right prism] preview Miss:", preview(prR as any, sMiss));
+console.log("[Right prism] review 42:", review(prR as any, 42));
+console.log("[Right prism] over (+1) Hit:", over(prR as any, (n:number)=>n+1)(sHit));
+console.log("[Right prism] over (+1) Miss:", over(prR as any, (n:number)=>n+1)(sMiss));
+
+const rightLaws = checkPrismLaws(
+  prR as any,
+  (b:number)=> Right<string,number>(b),
+  (s:Either<string,number>)=> s.tag==="right"? Right(s.right) : Left(Left<string,number>(s.left)),
+  sHit, sMiss, 3, 9
+);
+console.log("[Right prism] laws:", rightLaws);
+console.log();
+
+// Example 2: numberStringPrism
+console.log("🔍 Example 2: Number-String Prism");
+console.log("==================================");
+console.log("Valid number string '123':", preview(numberStringPrism as any, "123"));
+console.log("Invalid number string '12x':", preview(numberStringPrism as any, "12x"));
+console.log("Review number 88:", review(numberStringPrism as any, 88));
+console.log("Over (*2) on '21':", over(numberStringPrism as any, (n:number)=>n*2)("21"));
+console.log("Over (*2) on 'abc':", over(numberStringPrism as any, (n:number)=>n*2)("abc"));
+
+const numStrLaws = checkPrismLaws(
+  numberStringPrism as any,
+  (b:number)=> String(b),
+  (s:string)=> {
+    const n = Number(s);
+    return Number.isFinite(n)&&String(n)===s ? Right(n) : Left(s);
+  },
+  "5", "oops", 11, 22
+);
+console.log("[num<->str] laws:", numStrLaws);
+console.log();
+
+// Example 3: Left prism
+console.log("🔍 Example 3: Left Prism");
+console.log("=========================");
+const prL = leftPrism<string, string, number>();
+
+const leftHit: Either<string, number> = Left("error");
+const leftMiss: Either<string, number> = Right(42);
+
+console.log("Left Hit:", leftHit);
+console.log("Left Miss:", leftMiss);
+console.log("[Left prism] preview Hit:", preview(prL as any, leftHit));
+console.log("[Left prism] preview Miss:", preview(prL as any, leftMiss));
+console.log("[Left prism] review 'warn':", review(prL as any, "warn"));
+console.log("[Left prism] over (s => s.toUpperCase()) Hit:", 
+  over(prL as any, (s:string)=>s.toUpperCase())(leftHit));
+console.log("[Left prism] over (s => s.toUpperCase()) Miss:", 
+  over(prL as any, (s:string)=>s.toUpperCase())(leftMiss));
+
+const leftLaws = checkPrismLaws(
+  prL as any,
+  (s:string)=> Left<string,number>(s),
+  (e:Either<string,number>)=> e.tag==="left"? Right(e.left) : Left(Right<string,number>(e.right)),
+  leftHit, leftMiss, "test1", "test2"
+);
+console.log("[Left prism] laws:", leftLaws);

--- a/src/examples/traversal-example.ts
+++ b/src/examples/traversal-example.ts
@@ -1,0 +1,131 @@
+/**
+ * Developer Demo:
+ * - This file is not part of the library build.
+ * - Do not import it from 'src/index.ts' or 'src/types/index.ts'.
+ */
+
+// traversal-example.ts
+import { Either, Left, Right } from "../types/catkit-prisms.js";
+import { lens } from "../types/catkit-optics.js";
+import { prism, rightPrism } from "../types/catkit-prisms.js";
+import { 
+  Traversal, eachArray, bothPair, overO, setO, toListOf, previewO, viewO, composeO,
+  checkTraversalIdentity, checkTraversalFusion, checkTraversalNaturality_Length, checkTraversalLinearity_Count
+} from "../types/catkit-traversal.js";
+
+console.log("🎯 Unified Optics Demo: Lens + Prism + Traversal");
+console.log("================================================\n");
+
+console.log("📊 What we're demonstrating:");
+console.log("• Unified helpers that work across all optic types");
+console.log("• Lens: focuses single field");
+console.log("• Prism: focuses sum type branch (0 or 1 focus)");
+console.log("• Traversal: focuses multiple elements (0 to n foci)");
+console.log("• Composition and law checking");
+console.log();
+
+// Lens: prop 'x'
+type S = { x:number, y:string };
+const lx = lens<S,S,number,number>(
+  s => s.x,
+  (s,b)=> ({...s, x:b})
+) as any;
+
+// Prism: Right branch
+const prR = rightPrism<string, number, number>() as any;
+
+// Traversal: elements of an array
+const arrTrav = eachArray as Traversal<number[], number[], number, number>;
+
+console.log("🔍 Example 1: Lens Operations");
+console.log("==============================");
+const obj = {x:7, y:"hello"};
+console.log("Original object:", obj);
+console.log("[lens] viewO:", viewO(lx as any, obj));
+console.log("[lens] overO (+10):", overO(lx as any, (n:number)=>n+10)(obj));
+console.log("[lens] setO 99:", setO(lx as any, 99)(obj));
+console.log("[lens] toListOf:", toListOf(lx as any, obj));
+console.log();
+
+console.log("🔍 Example 2: Prism Operations");
+console.log("===============================");
+const rightVal: Either<string, number> = Right(5);
+const leftVal: Either<string, number> = Left("error");
+
+console.log("Right value:", rightVal);
+console.log("Left value:", leftVal);
+console.log("[prism] previewO Right(5):", previewO(prR as any, rightVal));
+console.log("[prism] previewO Left('error'):", previewO(prR as any, leftVal));
+console.log("[prism] overO (+1) Right(5):", overO(prR as any, (n:number)=>n+1)(rightVal));
+console.log("[prism] setO 99 Left('error'):", setO(prR as any, 99)(leftVal));
+console.log("[prism] toListOf Right(5):", toListOf(prR as any, rightVal));
+console.log("[prism] toListOf Left('error'):", toListOf(prR as any, leftVal));
+console.log();
+
+console.log("🔍 Example 3: Traversal Operations");
+console.log("===================================");
+const arr = [1, 2, 3, 4];
+console.log("Original array:", arr);
+console.log("[traversal] toListOf:", toListOf(arrTrav as any, arr));
+console.log("[traversal] overO (*2):", overO(arrTrav as any, (n:number)=>n*2)(arr));
+console.log("[traversal] setO 42:", setO(arrTrav as any, 42)(arr));
+console.log("[traversal] previewO:", previewO(arrTrav as any, arr));
+console.log();
+
+// Compose traversal with lens: traverse array of objects focusing .x
+console.log("🔍 Example 4: Composed Optics (Array of Objects → .x field)");
+console.log("============================================================");
+const arrOfObjs = [{x:1,y:"a"}, {x:2,y:"b"}, {x:3,y:"c"}];
+
+const travObjsX: any = <P>(dict:any)=>(pab:any)=>(dict.wander(
+  <F,Box<_>>(F:any)=> (ab:any)=> (xs:S[])=> {
+    // map each element via lens's Strong-based morphism
+    const dictL = { dimap:dict.dimap, first:dict.first } as any;
+    const pabL  = (lx as any)(dictL)(pab);
+    // now pabL : Star F S S ; apply to each element like eachArray
+    let acc = F.of([] as S[]);
+    for (const s of xs) {
+      const step = pabL(s); // F S
+      const cons = (ys:S[]) => (z:S)=> ys.concat([z]);
+      acc = F.ap(F.map(acc, (ys:S[])=> (f:(ys:S[])=>S[])=> f(ys)), F.map(step, (z:S)=> (ys:S[])=> ys.concat([z])));
+    }
+    return acc;
+  }, pab));
+
+console.log("Array of objects:", arrOfObjs);
+console.log("[composed] toListOf (all .x values):", toListOf(travObjsX, arrOfObjs));
+console.log("[composed] overO (+1) (increment all .x):", overO(travObjsX, (n:number)=>n+1)(arrOfObjs));
+console.log("[composed] setO 100 (set all .x to 100):", setO(travObjsX, 100)(arrOfObjs));
+console.log();
+
+// Pair traversal example
+console.log("🔍 Example 5: Pair Traversal");
+console.log("=============================");
+const pair: [number, number] = [10, 20];
+const pairTrav = bothPair<number, number, number, number>() as any;
+
+console.log("Original pair:", pair);
+console.log("[pair] toListOf:", toListOf(pairTrav, pair));
+console.log("[pair] overO (*3):", overO(pairTrav, (n:number)=>n*3)(pair));
+console.log("[pair] setO 555:", setO(pairTrav, 555)(pair));
+console.log();
+
+// Laws checks
+console.log("🔍 Example 6: Traversal Laws");
+console.log("============================");
+const testArr = [1, 2, 3];
+const f = (n:number)=> n+1;
+const g = (n:number)=> n*3;
+
+console.log("Test array:", testArr);
+console.log("[laws] Identity:", checkTraversalIdentity(arrTrav as any, testArr));
+console.log("[laws] Fusion:", checkTraversalFusion(arrTrav as any, testArr, f, g));
+console.log("[laws] Naturality (length):", checkTraversalNaturality_Length(arrTrav as any, testArr));
+console.log("[laws] Linearity (count):", checkTraversalLinearity_Count(arrTrav as any, testArr));
+console.log();
+
+console.log("🎯 All unified helpers work seamlessly across Lens, Prism, and Traversal!");
+console.log("• overO/setO: modify through any optic");
+console.log("• toListOf: collect all foci (1 for lens, 0-1 for prism, 0-n for traversal)");
+console.log("• previewO: safely get first focus");
+console.log("• viewO: get exactly-one focus (lens-style)");

--- a/src/types/catkit-prisms.ts
+++ b/src/types/catkit-prisms.ts
@@ -1,0 +1,181 @@
+// catkit-prisms.ts
+// Profunctor **prisms** with Choice, plus a tiny laws test kit.
+// Works side-by-side with catkit-optics.ts (lenses).
+
+// ----------------- Sum/Option helpers -----------------
+export type Either<L, R> = { tag: "left";  left: L } | { tag: "right"; right: R };
+export const Left  = <L,R>(l:L): Either<L,R> => ({ tag:"left",  left:l });
+export const Right = <L,R>(r:R): Either<L,R> => ({ tag:"right", right:r });
+
+export type Option<A> = { tag:"none" } | { tag:"some"; value:A };
+export const None  : Option<never> = { tag:"none" };
+export const Some  = <A>(a:A): Option<A> => ({ tag:"some", value:a });
+
+const deepEq = (x:any,y:any)=> JSON.stringify(x)===JSON.stringify(y);
+
+// ----------------- Profunctor core -----------------
+export type PVal<P, A, B> = any;
+export interface ProfDict<P> {
+  dimap: <A,B,C,D>(p: PVal<P,A,B>, l:(c:C)=>A, r:(b:B)=>D) => PVal<P,C,D>;
+}
+
+export interface ChoiceDict<P> extends ProfDict<P> {
+  left : <A,B,C>(p: PVal<P,A,B>) => PVal<P, Either<A,C>, Either<B,C>>;
+  right: <A,B,C>(p: PVal<P,A,B>) => PVal<P, Either<C,A>, Either<C,B>>;
+}
+
+// Prism encoding: Prism s t a b := forall p. Choice p => p a b -> p s t
+export type Prism<S,T,A,B> = <P>(dict: ChoiceDict<P>) => (pab: PVal<P,A,B>) => PVal<P,S,T>;
+
+// ----------------- Concrete profunctors -----------------
+
+// Function profunctor (maps along Either using standard functor maps)
+export type Fn<A,B> = (a:A)=>B;
+export const ChoiceFn: ChoiceDict<"Fn"> = {
+  dimap: <A,B,C,D>(p: Fn<A,B>, l: (c:C)=>A, r: (b:B)=>D): Fn<C,D> =>
+    (c:C)=> r(p(l(c))),
+  left:  <A,B,C>(p: Fn<A,B>): Fn<Either<A,C>, Either<B,C>> =>
+    (e) => e.tag==="left" ? Left(p(e.left)) : e,
+  right: <A,B,C>(p: Fn<A,B>): Fn<Either<C,A>, Either<C,B>> =>
+    (e) => e.tag==="right" ? Right(p(e.right)) : e
+};
+
+// Forget profunctor for preview: Forget<Option<R>, A, _> = A -> Option<R>
+export type Forget<R,A,_B=unknown> = (a:A)=>R;
+export function ChoiceForget<R>(): ChoiceDict<"Forget"> {
+  return {
+    dimap: <A,B,C,D>(p: Forget<R,A,B>, l: (c:C)=>A, _r: (b:B)=>D): Forget<R,C,D> =>
+      (c:C)=> p(l(c)),
+    left:  <A,B,C>(p: Forget<R,A,B>): Forget<R, Either<A,C>, Either<B,C>> =>
+      (e)=> e.tag==="left" ? p(e.left) : (undefined as any as R),
+    right: <A,B,C>(p: Forget<R,A,B>): Forget<R, Either<C,A>, Either<C,B>> =>
+      (e)=> e.tag==="right"? p(e.right) : (undefined as any as R)
+  };
+}
+// Specialize to Option by supplying a default for the non-focused branch
+export function ChoiceForgetOption<R>(none: R): ChoiceDict<"Forget"> {
+  return {
+    dimap: <A,B,C,D>(p: Forget<R,A,B>, l: (c:C)=>A, _r: (b:B)=>D): Forget<R,C,D> =>
+      (c:C)=> p(l(c)),
+    left:  <A,B,C>(p: Forget<R,A,B>): Forget<R, Either<A,C>, Either<B,C>> =>
+      (e)=> e.tag==="left" ? p(e.left) : none,
+    right: <A,B,C>(p: Forget<R,A,B>): Forget<R, Either<C,A>, Either<C,B>> =>
+      (e)=> e.tag==="right"? p(e.right) : none
+  };
+}
+
+// Tagged profunctor for review: ignores input, carries output B
+export type Tagged<B, A = unknown> = { value: B };
+export const ChoiceTagged: ChoiceDict<"Tagged"> = {
+  dimap: <A,B,C,D>(p: Tagged<B,A>, _l: (c:C)=>A, r: (b:B)=>D): Tagged<D,C> =>
+    ({ value: r(p.value) }),
+  left:  <A,B,C>(p: Tagged<B,A>): Tagged<Either<B,C>, Either<A,C>> =>
+    ({ value: Left(p.value) }),
+  right: <A,B,C>(p: Tagged<B,A>): Tagged<Either<C,B>, Either<C,A>> =>
+    ({ value: Right(p.value) })
+};
+
+// ----------------- Prism constructor & interpreters -----------------
+
+export function prism<S,T,A,B>(
+  build: (b:B)=>T,
+  match: (s:S)=> Either<T, A>
+): Prism<S,T,A,B> {
+  return <P>(dict: ChoiceDict<P>) =>
+    (pab: PVal<P,A,B>): PVal<P,S,T> => {
+      // right pab : p (Either<T,A>) (Either<T,B>)
+      const righted = dict.right<A,B,T>(pab as any);
+      // dimap match (either id build)
+      const post = (e: Either<T,B>): T => e.tag==="left" ? e.left : build(e.right);
+      return dict.dimap(righted, match, post);
+    };
+}
+
+// preview: S -> Option<A>
+export function preview<S,A>(pr: Prism<S,S,A,A>, s:S): Option<A> {
+  const P = ChoiceForgetOption<Option<A>>(None);
+  const pab: Forget<Option<A>, A, A> = (a:A)=> Some(a);
+  const ps: Forget<Option<A>, S, S>  = pr(P)(pab) as any;
+  return ps(s);
+}
+
+// review: B -> T
+export function review<T,B>(pr: Prism<any,T,any,B>, b:B): T {
+  const tagged: Tagged<B, any> = { value: b };
+  const out: Tagged<T, any> = pr(ChoiceTagged)(tagged) as any;
+  return out.value;
+}
+
+// over: S -> T by acting on A with (a->b)
+export function over<S,T,A,B>(pr: Prism<S,T,A,B>, f:(a:A)=>B): (s:S)=>T {
+  const pab: Fn<A,B> = f;
+  const ps: Fn<S,T>  = pr(ChoiceFn)(pab) as any;
+  return ps;
+}
+
+// ----------------- Prism laws test kit -----------------
+
+export type PrismLawReport = {
+  buildMatch: boolean;         // match (review b) = Right b
+  previewReview: boolean;      // preview (review b) = Some b
+  missNoOp: boolean;           // over f leaves non-matching s unchanged
+  compFusion: boolean;         // over g ∘ over f = over (g∘f) on a hit
+};
+
+export function checkPrismLaws<S,T,A,B>(
+  pr: Prism<S,T,A,B>,
+  build: (b:B)=>T,
+  match: (s:S)=> Either<T,A>,
+  sampleHit: S,    // an s that matches (Right _)
+  sampleMiss: S,   // an s that fails (Left _)
+  a1: B, a2: B
+): PrismLawReport {
+  // build-match
+  const bm = deepEq(match(review(pr, a1)), Right(a1));
+
+  // preview-review
+  const prr = deepEq(preview(pr as any, review(pr, a1)), Some(a1 as any));
+
+  // miss-no-op
+  const f = (x:any)=> a1;
+  const miss = over(pr, f)(sampleMiss);
+  const mNoOp = deepEq(miss, sampleMiss);
+
+  // compFusion on a hit
+  const g = (x:any)=> a2;
+  const lhs = over(pr, g)(over(pr, f)(sampleHit));
+  const rhs = over(pr, (x:any)=> g(f(x)))(sampleHit);
+  const cf  = deepEq(lhs, rhs);
+
+  return { buildMatch: bm, previewReview: prr, missNoOp: mNoOp, compFusion: cf };
+}
+
+// ----------------- Example prisms -----------------
+
+// Focus Right of Either<L, A> → Either<L, B>
+export function rightPrism<L,A,B>(): Prism<Either<L,A>, Either<L,B>, A, B> {
+  return prism(
+    (b:B): Either<L,B> => Right(b),
+    (s:Either<L,A>): Either<Either<L,B>, A> =>
+      s.tag==="right" ? Right(s.right) : Left(Left(s.left))
+  );
+}
+
+// Focus Left of Either<L, A> → Either<L', A>
+export function leftPrism<L,Lp,A>(): Prism<Either<L,A>, Either<Lp,A>, L, Lp> {
+  return prism(
+    (l:Lp): Either<Lp,A> => Left(l),
+    (s:Either<L,A>): Either<Either<Lp,A>, L> =>
+      s.tag==="left" ? Right(s.left) : Left(Right(s.right))
+  );
+}
+
+// Number-as-string prism: string ↔ number (partial)
+export const numberStringPrism: Prism<string,string,number,number> =
+  prism(
+    (n:number)=> String(n),
+    (s:string)=> {
+      const n = Number(s);
+      return Number.isFinite(n) && String(n)===s ? Right(n) : Left(s);
+    }
+  );

--- a/src/types/catkit-prisms.ts
+++ b/src/types/catkit-prisms.ts
@@ -131,10 +131,11 @@ export function checkPrismLaws<S,T,A,B>(
   a1: B, a2: B
 ): PrismLawReport {
   // build-match
-  const bm = deepEq(match(review(pr, a1)), Right(a1));
+  const reviewedValue = review(pr, a1);
+  const bm = deepEq(match(reviewedValue as any), Right(a1));
 
   // preview-review
-  const prr = deepEq(preview(pr as any, review(pr, a1)), Some(a1 as any));
+  const prr = deepEq(preview(pr as any, reviewedValue as any), Some(a1 as any));
 
   // miss-no-op
   const f = (x:any)=> a1;
@@ -143,7 +144,8 @@ export function checkPrismLaws<S,T,A,B>(
 
   // compFusion on a hit
   const g = (x:any)=> a2;
-  const lhs = over(pr, g)(over(pr, f)(sampleHit));
+  const hitAfterF = over(pr, f)(sampleHit);
+  const lhs = over(pr as any, g)(hitAfterF as any);
   const rhs = over(pr, (x:any)=> g(f(x)))(sampleHit);
   const cf  = deepEq(lhs, rhs);
 

--- a/src/types/catkit-traversal.ts
+++ b/src/types/catkit-traversal.ts
@@ -1,0 +1,256 @@
+// catkit-traversal.ts
+// Traversals via profunctor *Wander* using Star<F> for Applicative F.
+// Unified helpers: overO / setO / toListOf / previewO / viewO / composeO
+// Traversal laws checkers (identity, fusion, naturality via App morphism, linearity)
+// Extra traversals: eitherTraversal (Right), optionTraversal (Some)
+
+import { Left, Right, Either, Option, Some, None } from "./catkit-prisms.js"; // reuse Either/Option
+
+// ----------------- Applicative machinery -----------------
+export interface Applicative<F, Box> {
+  of: <A>(a:A)=> any; // Box<A>
+  map: <A,B>(fa: any, f:(a:A)=>B)=> any; // Box<A> -> Box<B>
+  ap:  <A,B>(ff: any, fa: any)=> any; // Box<(a:A)=>B> -> Box<A> -> Box<B>
+  liftA2?: <A,B,C>(f:(a:A,b:B)=>C, fa:any, fb:any)=> any; // Box<A> -> Box<B> -> Box<C>
+}
+
+// Identity applicative
+export type Id<A> = { tag:"Id", value:A };
+export const IdApp: Applicative<"Id", any> = {
+  of: (a)=> ({tag:"Id", value:a}),
+  map: (fa, f)=> ({tag:"Id", value: f(fa.value)}),
+  ap: (ff, fa)=> ({tag:"Id", value: ff.value(fa.value)}),
+  liftA2: (f, fa, fb)=> ({tag:"Id", value: f(fa.value, fb.value)})
+};
+
+// Const applicative with a Monoid (for toListOf, counting, etc.)
+export interface Monoid<M> { empty: M; concat:(x:M,y:M)=>M; }
+export type Const<M,A> = { tag:"Const", value:M };
+export function ConstApp<M>(M: Monoid<M>): Applicative<"Const", any> {
+  return {
+    of: (_: any)=> ({tag:"Const", value: M.empty}),
+    map: (fa: any, _f: any)=> fa,
+    ap: (ff: any, fa: any)=> ({tag:"Const", value: M.concat(ff.value, fa.value)})
+  } as any;
+}
+export const MonoidArray: Monoid<any[]> = { empty: [], concat:(x,y)=> x.concat(y) };
+export const MonoidSum: Monoid<number>   = { empty: 0, concat:(x,y)=> x+y };
+
+// Compose applicatives
+export type Compose<A> = { tag:"Compose", value: any }; // value: F (G A)
+export function ComposeApp<F, G>(
+  F: Applicative<F, any>,
+  G: Applicative<G, any>
+): Applicative<"Compose", any> {
+  return {
+    of: <A>(a:A)=> ({tag:"Compose", value: F.of( G.of(a) )}),
+    map: <A,B>(c: any, f:(a:A)=>B)=> ({tag:"Compose", value: F.map(c.value, (ga:any)=> G.map(ga, f))}),
+    ap:  <A,B>(cf: any, ca: any)=> ({
+      tag:"Compose",
+      value: F.ap( F.map(cf.value, (gf:any)=> (ga:any)=> G.ap(gf, ga)), ca.value )
+    })
+  } as any;
+}
+
+// Applicative morphism (for naturality checks)
+export interface AppMorphism<F1, F2> {
+  phi: <A>(fa: any) => any; // Box1<A> -> Box2<A>
+  // should satisfy: phi(of a) = of a ; phi(ap(ff,fa)) = ap(phi ff, phi fa)
+}
+
+// ----------------- Star profunctor over an Applicative -----------------
+
+export type Star<A, B> = (a:A) => any; // returns Box<B>
+
+export interface WanderDict<P> {
+  dimap:  <A,B,C,D>(p: any, l:(c:C)=>A, r:(b:B)=>D)=> any;
+  first:  <A,B,C>(p: any)=> any;
+  left:   <A,B,C>(p: any)=> any;
+  right:  <A,B,C>(p: any)=> any;
+  // Core traversal op:
+  wander: <A,B,S,T>(
+    walk: <F>(F: Applicative<F, any>) => (ab: (a:A)=>any) => (s:S)=> any,
+    pab: any
+  )=> any;
+}
+
+// Build a Wander dict for Star<F> from an Applicative
+export function StarDict<F>(F: Applicative<F, any>): WanderDict<"Star"> {
+  const dimap = <A,B,C,D>(p: Star<A, B>, l:(c:C)=>A, r:(b:B)=>D): Star<C, D> =>
+    (c:C)=> F.map(p(l(c)), r as any);
+  const first = <A,B,C>(p: Star<A, B>): Star<[A,C], [B,C]> =>
+    ([a,c]:[A,C])=> F.map(p(a), (b:B)=> [b, c] as [B,C]);
+  const left  = <A,B,C>(p: Star<A, B>): Star<Either<A,C>, Either<B,C>> =>
+    (e: Either<A,C>) => e.tag==="left"
+      ? F.map(p(e.left), (b:B)=> Left<B,C>(b))
+      : F.of(Right<B,C>(e.right));
+  const right = <A,B,C>(p: Star<A, B>): Star<Either<C,A>, Either<C,B>> =>
+    (e: Either<C,A>) => e.tag==="right"
+      ? F.map(p(e.right), (b:B)=> Right<C,B>(b))
+      : F.of(Left<C,B>(e.left));
+  const wander = <A,B,S,T>(
+    walk: <FF>(FF: Applicative<FF, any>) => (ab: (a:A)=>any) => (s:S)=> any,
+    pab: Star<A, B>
+  ): Star<S, T> => (s:S)=> walk(F as any)((a:A)=> pab(a))(s);
+  return { dimap, first, left, right, wander };
+}
+
+// ----------------- Traversal encoding -----------------
+// Traversal s t a b  :=  forall p. Wander p => p a b -> p s t
+export type Traversal<S,T,A,B> = <P>(dict: WanderDict<P>) => (pab:any)=> any;
+
+// Construct a traversal from a *walker* (Applicative-based)
+export function traversal<S,T,A,B>(
+  walk: <F>(F: Applicative<F, any>) => (ab: (a:A)=> any) => (s:S)=> any
+): Traversal<S,T,A,B> {
+  return <P>(dict: WanderDict<P>) => (pab:any) => dict.wander<A,B,S,T>(walk, pab);
+}
+
+// Some basic traversals
+export const eachArray: Traversal<any[], any[], any, any> =
+  traversal<any[], any[], any, any>(<F>(F: Applicative<F, any>) =>
+    (ab: (a:any)=> any) => (xs:any[]) => {
+      let acc = F.of([] as any[]);
+      for (const x of xs) {
+        const fx = ab(x); // F b
+        // acc: F [b]; fx: F b ; combine to F [b]
+        const snoc = (ys:any[]) => (b:any)=> ys.concat([b]);
+        const step = F.map(fx, (b:any)=> (ys:any[])=> ys.concat([b]));
+        acc = F.ap( F.map(acc, (ys:any[])=> (k:(ys:any[])=>any[])=> k(ys)), step as any);
+      }
+      return acc;
+    }
+  );
+
+export function bothPair<A,B,C,D>(): Traversal<[A,B],[C,D],A|B,C|D> {
+  return traversal<[A,B],[C,D],any,any>(<F>(F: Applicative<F, any>) =>
+    (ab: (a:any)=> any) => ([a,b]:[A,B]) => {
+      const fa = ab(a); const fb = ab(b);
+      const pair = (x:any)=> (y:any)=> [x,y] as [C,D];
+      return F.ap(F.map(fa, pair), fb);
+    }
+  );
+}
+
+// Either traversal (Right branch)
+export function eitherTraversal<L,A,B>(): Traversal<Either<L,A>, Either<L,B>, A, B> {
+  return traversal(<F>(F: Applicative<F, any>) =>
+    (ab:(a:A)=>any)=> (e: Either<L,A>) =>
+      e.tag==="right" ? F.map(ab(e.right), (b:B)=> Right<L,B>(b))
+                      : F.of(Left<L,B>(e.left))
+  );
+}
+
+// Option traversal (Some branch)
+export function optionTraversal<A,B>(): Traversal<Option<A>, Option<B>, A, B> {
+  return traversal(<F>(F: Applicative<F, any>) =>
+    (ab:(a:A)=>any)=> (o: Option<A>) =>
+      o.tag==="some" ? F.map(ab(o.value), (b:B)=> ({tag:"some", value:b} as Option<B>))
+                     : F.of(None as Option<B>)
+  );
+}
+
+// ----------------- Unified helpers for any optic -----------------
+
+export type AnyOptic<S,T,A,B> = <P>(dict: WanderDict<P>) => (pab:any)=> any;
+
+// compose any two optics (o1 ∘ o2)
+export function composeO<S,T,A,B,C,D>(
+  o1: AnyOptic<S,T,A,B>,
+  o2: AnyOptic<A,B,C,D>
+): AnyOptic<S,T,C,D> {
+  return <P>(dict: WanderDict<P>) => (pcd:any) => {
+    const pab = o2(dict)(pcd);
+    return o1(dict)(pab);
+  };
+}
+
+// overO works for Lens, Prism, Traversal
+export function overO<S,T,A,B>(optic: AnyOptic<S,T,A,B>, f:(a:A)=>B): (s:S)=>T {
+  const dict = StarDict(IdApp);
+  const star = (a:A)=> IdApp.of(f(a));
+  const res  = optic(dict)(star) as (s:S)=> Id<A>;
+  return (s:S)=> (res(s) as any).value as T;
+}
+
+// setO: constant replace
+export function setO<S,T,A,B>(optic: AnyOptic<S,T,A,B>, b:B): (s:S)=>T {
+  return overO(optic, () => b);
+}
+
+// toListOf: collect all foci (lens→1, prism→0/1, traversal→many)
+export function toListOf<S,T,A,B>(optic: AnyOptic<S,T,A,B>, s:S): A[] {
+  const C = ConstApp<{xs:A[]}>({
+    empty: {xs: [] as A[]},
+    concat: (x,y)=> ({xs: (x.xs as A[]).concat(y.xs as A[])})
+  });
+  const dict = StarDict(C as any);
+  const star = (a:A)=> ({tag:"Const", value:{xs:[a] as A[]}});
+  const res  = optic(dict)(star) as (s:S)=> {tag:"Const", value:{xs:A[]}};
+  return (res(s).value.xs);
+}
+
+// previewO: Option first focus (if any)
+export function previewO<S,T,A,B>(optic: AnyOptic<S,T,A,B>, s:S): Option<A> {
+  const xs = toListOf<S,T,A,B>(optic, s);
+  return xs.length>0 ? Some(xs[0]!) : None;
+}
+
+// viewO: expect exactly one focus (lens-like); throws otherwise
+export function viewO<S,A>(optic: AnyOptic<S,S,A,A>, s:S): A {
+  const xs = toListOf<S,S,A,A>(optic, s);
+  if (xs.length!==1) throw new Error(`viewO: expected exactly 1 focus, got ${xs.length}`);
+  return xs[0]!;
+}
+
+// Expose low-level "traverse" runner for tests
+export function traverseWith<S,T,A,B,F>(
+  optic: AnyOptic<S,T,A,B>, F: Applicative<F,any>, ab:(a:A)=> any
+): (s:S)=> any {
+  const dict = StarDict(F);
+  return optic(dict)(ab) as any;
+}
+
+// ----------------- Laws checkers -----------------
+
+export function checkTraversalIdentity<S,T,A,B>(optic: AnyOptic<S,T,A,B>, s:S): boolean {
+  const id = (x:any)=> x;
+  return JSON.stringify(overO(optic as any, id)(s)) === JSON.stringify(s);
+}
+
+export function checkTraversalFusion<S,T,A,B>(optic: AnyOptic<S,T,A,B>, s:S, f:(a:A)=>B, g:(b:B)=>any): boolean {
+  const lhs = overO(optic as any, g)(overO(optic as any, f)(s));
+  const rhs = overO(optic as any, (x:any)=> g(f(x)))(s);
+  return JSON.stringify(lhs) === JSON.stringify(rhs);
+}
+
+// Naturality via an applicative morphism φ : Const<List> → Const<Sum>
+// Instantiate traversal with Const<List<A>> using ab = singleton list, then map through φ to get counts;
+// compare to traversing with Const<Sum> and ab' = 1.
+export function checkTraversalNaturality_Length<S,T,A,B>(optic: AnyOptic<S,T,A,B>, s:S): boolean {
+  // left side: Const<List>
+  type LBox = Const<{xs:any[]}, any>;
+  const CList = ConstApp<{xs:any[]}>({
+    empty: {xs:[]}, concat: (x,y)=> ({xs: x.xs.concat(y.xs)})
+  });
+  const abList = (_a:any)=> ({tag:"Const", value:{xs:[null]}} as LBox);
+  const left  = traverseWith<S,T,A,B, "Const">(optic as any, CList as any, abList)(s) as any;
+  const phi   = (cl: LBox) => ({tag:"Const", value: cl.value.xs.length}) as Const<number, any>;
+  const leftCount = phi(left).value;
+
+  // right side: Const<Sum>
+  const CSum = ConstApp<number>(MonoidSum);
+  const abOne = (_a:any)=> ({tag:"Const", value: 1}) as Const<number, any>;
+  const rightCount = traverseWith(optic as any, CSum as any, abOne)(s).value as number;
+
+  return leftCount === rightCount;
+}
+
+// Linearity (no duplication/deletion): counting applicative
+export function checkTraversalLinearity_Count<S,T,A,B>(optic: AnyOptic<S,T,A,B>, s:S): boolean {
+  const n = toListOf(optic as any, s).length;
+  const CSum = ConstApp<number>(MonoidSum);
+  const abOne = (_a:any)=> ({tag:"Const", value: 1}) as Const<number, any>;
+  const count = traverseWith(optic as any, CSum as any, abOne)(s).value as number;
+  return count === n;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -44,6 +44,14 @@ export * from './category-to-nerve-sset.js';
 import * as CatkitOptics from './catkit-optics.js';
 export { CatkitOptics };
 
+// Catkit prisms (profunctor prisms with Choice) - use namespace to avoid conflicts
+import * as CatkitPrisms from './catkit-prisms.js';
+export { CatkitPrisms };
+
+// Catkit traversals (profunctor traversals with Wander + unified helpers) - use namespace to avoid conflicts
+import * as CatkitTraversal from './catkit-traversal.js';
+export { CatkitTraversal };
+
 // Equality helpers - use namespace to avoid conflicts
 import * as Eq from './eq.js';
 export { Eq };


### PR DESCRIPTION
Add profunctor prisms and traversals with unified optics helpers and law test kits.

This PR extends the existing profunctor optics suite (lenses) by introducing prisms for sum types and traversals for collections. It provides a complete set of composable optics with a unified API (`overO`, `setO`, `toListOf`, `previewO`, `viewO`) and robust law-checking capabilities, enhancing the library's ability to safely and functionally manipulate complex data structures.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f6b6a66-27e5-495b-b08a-a544de5d8bbc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6f6b6a66-27e5-495b-b08a-a544de5d8bbc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

