### PR TITLE
Consolidate and clean FP/CT library

### DIFF
--- a/src/universal/monad/LawvereMonad.ts
+++ b/src/universal/monad/LawvereMonad.ts
@@ -2,6 +2,7 @@ import { Term, Var, App } from "../Term";
 import { Signature, opOf } from "../Signature";
 import { normalize, rule, RewriteRule } from "../rewrite/Rules";
 import { must, idx } from "../../util/guards";
+import { FiniteSet } from "../../set/Set";
 
 /**
  * Lawvere Monad from a finitary theory
@@ -13,11 +14,8 @@ import { must, idx } from "../../util/guards";
  * - bind: T(X) × (X → T(Y)) → T(Y) (Kleisli extension)
  */
 
-/** A finite set with equality */
-export interface FiniteSet<A> {
-  elems: A[];
-  eq: (a: A, b: A) => boolean;
-}
+// Re-export FiniteSet from canonical location
+export { type FiniteSet } from "../../set/Set";
 
 /** The T-carrier (free algebra) on a finite set */
 export interface TCarrier<A> {

--- a/src/universal/rewrite/SetMonad.ts
+++ b/src/universal/rewrite/SetMonad.ts
@@ -2,6 +2,7 @@ import { Term, Var, App } from "../Term";
 import { Signature, opOf } from "../Signature";
 import { normalize, rule, RewriteRule } from "./Rules";
 import { idx } from "../../util/guards";
+import { FiniteSet } from "../../set/Set";
 
 /**
  * Set-level Monad from a finitary theory
@@ -13,9 +14,6 @@ import { idx } from "../../util/guards";
  * 
  * The monad laws are verified by testing on finite sets.
  */
-
-/** A finite set represented as an array of elements */
-export type FiniteSet<A> = A[];
 
 /** The free T-algebra on a finite set X */
 export type FreeAlgebra<A> = Term[];
@@ -121,7 +119,7 @@ export function testMonadLaws<A>(
 } {
   
   // Left identity: bind(unit(x), f) = f(x)
-  const leftIdentity = testSet.every(x => {
+  const leftIdentity = testSet.elems.every(x => {
     const unitX = monad.unit(x);
     const f = (a: A) => monad.unit(a); // Simple test function
     const bound = monad.bind(unitX, f);
@@ -132,7 +130,7 @@ export function testMonadLaws<A>(
   });
   
   // Right identity: bind(m, unit) = m
-  const rightIdentity = testSet.every(x => {
+  const rightIdentity = testSet.elems.every(x => {
     const m = monad.unit(x);
     const bound = monad.bind(m, monad.unit);
     
@@ -141,7 +139,7 @@ export function testMonadLaws<A>(
   });
   
   // Associativity: bind(bind(m, f), g) = bind(m, x => bind(f(x), g))
-  const associativity = testSet.every(x => {
+  const associativity = testSet.elems.every(x => {
     const m = monad.unit(x);
     const f = (a: A) => monad.unit(a);
     const g = (a: A) => monad.unit(a);

--- a/src/universal/rewrite/__tests__/set_monad.test.ts
+++ b/src/universal/rewrite/__tests__/set_monad.test.ts
@@ -4,9 +4,9 @@ import {
   createMonoidSetMonad, 
   createSemilatticeSetMonad,
   testMonadLaws,
-  type SetMonad,
-  type FiniteSet
+  type SetMonad
 } from "../SetMonad";
+import { type FiniteSet, mkFiniteSet } from "../../../set/Set";
 import { Signature } from "../../Signature";
 import { rule } from "../Rules";
 import { opOf } from "../../Signature";
@@ -81,7 +81,7 @@ describe("Set-level Monad from Finitary Theory", () => {
     });
     
     it("satisfies monad laws on small finite sets", () => {
-      const testSet: FiniteSet<string> = ["a", "b"];
+      const testSet: FiniteSet<string> = mkFiniteSet(["a", "b"], (a, b) => a === b);
       const laws = testMonadLaws(monad, testSet);
       
       // Note: The current implementation is simplified, so these tests
@@ -115,7 +115,7 @@ describe("Set-level Monad from Finitary Theory", () => {
     });
     
     it("satisfies monad laws on small finite sets", () => {
-      const testSet: FiniteSet<number> = [1, 2, 3];
+      const testSet: FiniteSet<number> = mkFiniteSet([1, 2, 3], (a, b) => a === b);
       const laws = testMonadLaws(monad, testSet);
       
       expect(typeof laws.leftIdentity).toBe("boolean");
@@ -128,25 +128,25 @@ describe("Set-level Monad from Finitary Theory", () => {
     const monad = createMonoidSetMonad<string>();
     
     it("tests left identity law", () => {
-      const testSet: FiniteSet<string> = ["x"];
+      const testSet: FiniteSet<string> = mkFiniteSet(["x"], (a, b) => a === b);
       const laws = testMonadLaws(monad, testSet);
       expect(laws.leftIdentity).toBeDefined();
     });
     
     it("tests right identity law", () => {
-      const testSet: FiniteSet<string> = ["y"];
+      const testSet: FiniteSet<string> = mkFiniteSet(["y"], (a, b) => a === b);
       const laws = testMonadLaws(monad, testSet);
       expect(laws.rightIdentity).toBeDefined();
     });
     
     it("tests associativity law", () => {
-      const testSet: FiniteSet<string> = ["z"];
+      const testSet: FiniteSet<string> = mkFiniteSet(["z"], (a, b) => a === b);
       const laws = testMonadLaws(monad, testSet);
       expect(laws.associativity).toBeDefined();
     });
     
     it("tests all laws together", () => {
-      const testSet: FiniteSet<string> = ["a", "b", "c"];
+      const testSet: FiniteSet<string> = mkFiniteSet(["a", "b", "c"], (a, b) => a === b);
       const laws = testMonadLaws(monad, testSet);
       
       expect(laws).toHaveProperty("leftIdentity");
@@ -159,7 +159,7 @@ describe("Set-level Monad from Finitary Theory", () => {
     const monad = createMonoidSetMonad<string>();
     
     it("handles empty finite sets", () => {
-      const testSet: FiniteSet<string> = [];
+      const testSet: FiniteSet<string> = mkFiniteSet([], (a, b) => a === b);
       const laws = testMonadLaws(monad, testSet);
       
       // Empty set should trivially satisfy all laws
@@ -169,7 +169,7 @@ describe("Set-level Monad from Finitary Theory", () => {
     });
     
     it("handles singleton sets", () => {
-      const testSet: FiniteSet<string> = ["single"];
+      const testSet: FiniteSet<string> = mkFiniteSet(["single"], (a, b) => a === b);
       const laws = testMonadLaws(monad, testSet);
       
       expect(typeof laws.leftIdentity).toBe("boolean");
@@ -178,7 +178,7 @@ describe("Set-level Monad from Finitary Theory", () => {
     });
     
     it("handles larger finite sets", () => {
-      const testSet: FiniteSet<number> = [1, 2, 3, 4, 5];
+      const testSet: FiniteSet<number> = mkFiniteSet([1, 2, 3, 4, 5], (a, b) => a === b);
       const laws = testMonadLaws(monad, testSet);
       
       expect(typeof laws.leftIdentity).toBe("boolean");

--- a/src/universal/rewrite/demo.ts
+++ b/src/universal/rewrite/demo.ts
@@ -18,6 +18,7 @@ import {
 import { Signature } from "../Signature";
 import { Var, App } from "../Term";
 import { must } from "../../util/guards";
+import { mkFiniteSet } from "../../set/Set";
 
 console.log("=== ORIENTED REWRITE SYSTEMS DEMO ===\n");
 
@@ -126,16 +127,16 @@ console.log("\n4. MONAD LAW VERIFICATION");
 console.log("=========================");
 
 // Test monad laws on finite sets
-const testSet1: string[] = ["a", "b"];
-const testSet2: number[] = [1, 2, 3];
+const testSet1 = mkFiniteSet(["a", "b"], (a, b) => a === b);
+const testSet2 = mkFiniteSet([1, 2, 3], (a, b) => a === b);
 
-console.log("Monoid Monad Laws on", testSet1, ":");
+console.log("Monoid Monad Laws on", testSet1.elems, ":");
 const monoidLaws = testMonadLaws(monoidMonad, testSet1);
 console.log("  Left Identity:", monoidLaws.leftIdentity);
 console.log("  Right Identity:", monoidLaws.rightIdentity);
 console.log("  Associativity:", monoidLaws.associativity);
 
-console.log("\nSemilattice Monad Laws on", testSet2, ":");
+console.log("\nSemilattice Monad Laws on", testSet2.elems, ":");
 const semilatticeLaws = testMonadLaws(semilatticeMonad, testSet2);
 console.log("  Left Identity:", semilatticeLaws.leftIdentity);
 console.log("  Right Identity:", semilatticeLaws.rightIdentity);
@@ -145,7 +146,7 @@ console.log("\n5. EDGE CASES");
 console.log("=============");
 
 // Empty set
-const emptySet: string[] = [];
+const emptySet = mkFiniteSet([], (a: string, b: string) => a === b);
 const emptyLaws = testMonadLaws(monoidMonad, emptySet);
 console.log("Empty set laws (should all be true):");
 console.log("  Left Identity:", emptyLaws.leftIdentity);
@@ -153,7 +154,7 @@ console.log("  Right Identity:", emptyLaws.rightIdentity);
 console.log("  Associativity:", emptyLaws.associativity);
 
 // Singleton set
-const singletonSet: string[] = ["single"];
+const singletonSet = mkFiniteSet(["single"], (a, b) => a === b);
 const singletonLaws = testMonadLaws(monoidMonad, singletonSet);
 console.log("\nSingleton set laws:");
 console.log("  Left Identity:", singletonLaws.leftIdentity);

--- a/src/universal/rewrite/index.ts
+++ b/src/universal/rewrite/index.ts
@@ -31,10 +31,12 @@ export {
 // Set-level monads
 export {
   type SetMonad,
-  type FiniteSet,
   type FreeAlgebra,
   createSetMonad,
   createMonoidSetMonad,
   createSemilatticeSetMonad,
   testMonadLaws
 } from "./SetMonad";
+
+// Re-export FiniteSet from canonical location
+export { type FiniteSet } from "../../set/Set";

--- a/src/util/guards.ts
+++ b/src/util/guards.ts
@@ -6,5 +6,5 @@ export function must<T>(x: T | undefined | null, msg = "Undefined"): T {
 
 export function idx<T>(arr: T[], i: number, msg = "Index out of range"): T {
   if (i < 0 || i >= arr.length) throw new Error(msg);
-  return arr[i];
+  return arr[i]!; // Safe after bounds check
 }


### PR DESCRIPTION
Consolidate the `FiniteSet` type definition and fix related import paths and usages to resolve duplicate definitions and TypeScript errors.

The `FiniteSet` type had three different definitions across the codebase, leading to inconsistencies and compilation errors. This PR unifies it to the most robust definition from `src/set/Set.ts`, which includes an explicit equality function, and updates all affected code to use this canonical type, thereby improving type safety and reducing cruft.

---
<a href="https://cursor.com/background-agent?bcId=bc-424189d7-be86-40c9-8378-f299908a3a97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-424189d7-be86-40c9-8378-f299908a3a97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

