### PR TITLE
Update category composition calls to compose

### DIFF
--- a/src/examples/category-to-nerve-demo.ts
+++ b/src/examples/category-to-nerve-demo.ts
@@ -40,7 +40,7 @@ function demonstrateCategoryToNerve() {
   
   // 3. Show composition in the free category
   console.log('3. Composition in Free Category:');
-  const fg = C_free.comp(g1, f1); // g ∘ f
+  const fg = C_free.compose(g1, f1); // g ∘ f
   console.log('   g ∘ f:', showPath(fg));
   console.log('   Note: g ∘ f ≠ h (different paths, same endpoints)');
   console.log();

--- a/src/examples/comprehensive-category-demo.ts
+++ b/src/examples/comprehensive-category-demo.ts
@@ -79,7 +79,7 @@ function Disc<X extends string>(objs: ReadonlyArray<X>): FiniteSmallCategory<X, 
     morphisms: objs.map(x=>({tag:"id", x})),
     id: (o:X)=>({tag:"id", x:o}),
     src:(m)=>m.x, dst:(m)=>m.x,
-    comp:(g,f)=> g.x===f.x ? g : (():any=>{throw new Error("discrete")})()
+    compose:(g,f)=> g.x===f.x ? g : (():any=>{throw new Error("discrete")})()
   };
 }
 type Id<X extends string> = { tag:"id", x:X };
@@ -128,7 +128,7 @@ const C1: SmallCategoryKan<CObj, CM> & { objects:CObj[]; morphisms:CM[] } = {
   id: (o)=> ({tag:"id", o}),
   src: (m)=> m.tag==="id" ? m.o : "X",
   dst: (m)=> m.tag==="id" ? m.o : "Y",
-  comp: (g,f) => {
+  compose: (g,f) => {
     const s = (m:CM)=> C1.src(m), d = (m:CM)=> C1.dst(m);
     if (d(f)!==s(g)) throw new Error("C comp mismatch");
     if (f.tag==="id") return g;
@@ -146,7 +146,7 @@ const D1: SmallCategoryKan<DObj, DM> & HasHom<DObj, DM> & { objects:DObj[] } = {
   id: (o)=> o==="d0" ? {tag:"id0"} : {tag:"id1"},
   src: (m)=> m.tag==="id0" ? "d0" : (m.tag==="id1" ? "d1" : "d0"),
   dst: (m)=> m.tag==="id0" ? "d0" : (m.tag==="id1" ? "d1" : "d1"),
-  comp: (g,f) => {
+  compose: (g,f) => {
     if (D1.dst(f)!==D1.src(g)) throw new Error("D comp mismatch");
     if (f.tag==="id0"||f.tag==="id1") return g;
     if (g.tag==="id0"||g.tag==="id1") return f;

--- a/src/examples/equivalence-example.ts
+++ b/src/examples/equivalence-example.ts
@@ -20,7 +20,7 @@ const A: SmallCategory<AObj,AM> & { objects:AObj[]; morphisms:AM[] } = {
   id: (o)=>({tag:"id",o}),
   src: (m)=> m.tag==="id" ? m.o : (m.tag==="s" ? "a0" : "a1"),
   dst: (m)=> m.tag==="id" ? m.o : (m.tag==="s" ? "a1" : "a0"),
-  comp: (g,f) => {
+  compose: (g,f) => {
     // type check
     if (A.dst(f)!==A.src(g)) throw new Error("A: bad comp");
     // identities
@@ -43,7 +43,7 @@ const B: SmallCategory<BObj,BM> & { objects:BObj[]; morphisms:BM[] } = {
   id: (o)=> o==="bX" ? {tag:"idX"} : {tag:"idY"},
   src: (m)=> m.tag==="idX" ? "bX" : (m.tag==="idY" ? "bY" : (m.tag==="sigma" ? "bX" : "bY")),
   dst: (m)=> m.tag==="idX" ? "bX" : (m.tag==="idY" ? "bY" : (m.tag==="sigma" ? "bY" : "bX")),
-  comp: (g,f) => {
+  compose: (g,f) => {
     if (B.dst(f)!==B.src(g)) throw new Error("B: bad comp");
     if (f.tag==="idX"||f.tag==="idY") return g;
     if (g.tag==="idX"||g.tag==="idY") return f;

--- a/src/examples/equivalence-nonstrict-example.ts
+++ b/src/examples/equivalence-nonstrict-example.ts
@@ -20,7 +20,7 @@ const A: SmallCategory<AObj,AM> & {objects:AObj[]; morphisms:AM[]} = {
   id:(o)=>({tag:"id",o}),
   src:(m)=> m.tag==="id" ? m.o : (m.tag==="s" ? "a0" : "a1"),
   dst:(m)=> m.tag==="id" ? m.o : (m.tag==="s" ? "a1" : "a0"),
-  comp:(g,f)=>{
+  compose:(g,f)=>{
     if (A.dst(f)!==A.src(g)) throw new Error("A comp");
     if (f.tag==="id") return g;
     if (g.tag==="id") return f;
@@ -40,7 +40,7 @@ const B: SmallCategory<BObj,BM> & {objects:BObj[]; morphisms:BM[]} = {
   id:(o)=> o==="bX"?{tag:"idX"}:o==="bY"?{tag:"idY"}:{tag:"idZ"},
   src:(m)=> m.tag==="idX"?"bX":m.tag==="idY"?"bY":m.tag==="idZ"?"bZ":(m.tag==="sigma"?"bX":"bY"),
   dst:(m)=> m.tag==="idX"?"bX":m.tag==="idY"?"bY":m.tag==="idZ"?"bZ":(m.tag==="sigma"?"bY":"bX"),
-  comp:(g,f)=>{
+  compose:(g,f)=>{
     if (B.dst(f)!==B.src(g)) throw new Error("B comp");
     if (f.tag==="idX"||f.tag==="idY"||f.tag==="idZ") return g;
     if (g.tag==="idX"||g.tag==="idY"||g.tag==="idZ") return f;

--- a/src/examples/kan-example-transport.ts
+++ b/src/examples/kan-example-transport.ts
@@ -24,7 +24,7 @@ const C: SmallCategory<CObj, CM> & { objects:CObj[]; morphisms:CM[] } = {
   id: (o: CObj)=> ({tag:"id", o}),
   src: (m: CM)=> m.tag==="id" ? m.o : "X",
   dst: (m: CM)=> m.tag==="id" ? m.o : "Y",
-  comp: (g: CM, f: CM) => {
+  compose: (g: CM, f: CM) => {
     const s = (m:CM)=> C.src(m), d = (m:CM)=> C.dst(m);
     if (d(f)!==s(g)) throw new Error("C comp mismatch");
     if (f.tag==="id") return g;
@@ -42,7 +42,7 @@ const D: SmallCategory<DObj, DM> & HasHom<DObj, DM> & { objects:DObj[] } = {
   id: (o: DObj)=> o==="d0" ? {tag:"id0"} : {tag:"id1"},
   src: (m: DM)=> m.tag==="id0" ? "d0" : (m.tag==="id1" ? "d1" : "d0"),
   dst: (m: DM)=> m.tag==="id0" ? "d0" : (m.tag==="id1" ? "d1" : "d1"),
-  comp: (g: DM, f: DM) => {
+  compose: (g: DM, f: DM) => {
     if (D.dst(f)!==D.src(g)) throw new Error("D comp mismatch");
     if (f.tag==="id0") return g;
     if (f.tag==="id1") return g;

--- a/src/examples/kan-extensions-with-assertions.ts
+++ b/src/examples/kan-extensions-with-assertions.ts
@@ -33,7 +33,7 @@ const C: SmallCategory<CObj, CM> & { objects:CObj[]; morphisms:CM[] } = {
   id: (o: CObj)=> ({tag:"id", o}),
   src: (m: CM)=> m.tag==="id" ? m.o : "X",
   dst: (m: CM)=> m.tag==="id" ? m.o : "Y",
-  comp: (g: CM, f: CM) => {
+  compose: (g: CM, f: CM) => {
     const s = (m:CM)=> C.src(m), d = (m:CM)=> C.dst(m);
     if (d(f)!==s(g)) throw new Error("C comp mismatch");
     if (f.tag==="id") return g;
@@ -51,7 +51,7 @@ const D: SmallCategory<DObj, DM> & HasHom<DObj, DM> & { objects:DObj[] } = {
   id: (o: DObj)=> o==="d0" ? {tag:"id0"} : {tag:"id1"},
   src: (m: DM)=> m.tag==="id0" ? "d0" : (m.tag==="id1" ? "d1" : "d0"),
   dst: (m: DM)=> m.tag==="id0" ? "d0" : (m.tag==="id1" ? "d1" : "d1"),
-  comp: (g: DM, f: DM) => {
+  compose: (g: DM, f: DM) => {
     if (D.dst(f)!==D.src(g)) throw new Error("D comp mismatch");
     if (f.tag==="id0"||f.tag==="id1") return g;
     if (g.tag==="id0"||g.tag==="id1") return f;

--- a/src/examples/kan-product-demo.ts
+++ b/src/examples/kan-product-demo.ts
@@ -28,7 +28,7 @@ const DiscreteCategory: SmallCategory<CObj, CM> & { objects: CObj[]; morphisms: 
   id: (o: CObj) => ({ tag: "id", o }),
   src: (m: CM) => m.o,
   dst: (m: CM) => m.o,
-  comp: (g: CM, f: CM) => {
+  compose: (g: CM, f: CM) => {
     if (g.o === f.o) return g;
     throw new Error("Cannot compose across different objects in discrete category");
   }
@@ -43,7 +43,7 @@ const TerminalCategory: SmallCategory<DObj, DM> & HasHom<DObj, DM> & { objects: 
   id: (_) => ({ tag: "id" }),
   src: (_) => "★",
   dst: (_) => "★", 
-  comp: (_g, _f) => ({ tag: "id" }),
+  compose: (_g, _f) => ({ tag: "id" }),
   hom: (_x, _y) => [{ tag: "id" }]
 };
 

--- a/src/examples/kan-ranset-worked-examples.ts
+++ b/src/examples/kan-ranset-worked-examples.ts
@@ -120,7 +120,7 @@ const ArrowCategory: SmallCategory<CObj, CM> & { objects: CObj[]; morphisms: CM[
   id: (o: CObj) => ({ tag: "id", o }),
   src: (m: CM) => m.tag === "id" ? m.o : "X",
   dst: (m: CM) => m.tag === "id" ? m.o : "Y",
-  comp: (g: CM, f: CM) => {
+  compose: (g: CM, f: CM) => {
     if (f.tag === "id") return g;
     if (g.tag === "id") return f;
     return { tag: "u" };
@@ -142,7 +142,7 @@ const TerminalCategory: SmallCategory<DObj, DM> & HasHom<DObj, DM> & { objects: 
   id: (_) => ({ tag: "id" }),
   src: (_) => "*",
   dst: (_) => "*",
-  comp: (_g, _f) => ({ tag: "id" }),
+  compose: (_g, _f) => ({ tag: "id" }),
   hom: (_x, _y) => [{ tag: "id" }]
 };
 
@@ -162,7 +162,7 @@ const DiscreteCategory: SmallCategory<DiscreteObj, DiscreteMor> & { objects: Dis
   id: (o: DiscreteObj) => ({ tag: "id", o }),
   src: (m: DiscreteMor) => m.o,
   dst: (m: DiscreteMor) => m.o,
-  comp: (g: DiscreteMor, f: DiscreteMor) => {
+  compose: (g: DiscreteMor, f: DiscreteMor) => {
     if (g.o === f.o) return g;
     throw new Error("Cannot compose morphisms between different objects");
   }

--- a/src/examples/kan-transport-iso-example.ts
+++ b/src/examples/kan-transport-iso-example.ts
@@ -19,7 +19,7 @@ const C: SmallCategory<CObj,CM> & {objects:CObj[]; morphisms:CM[]} = {
   id:(o)=>({tag:"id",o}), 
   src:(m)=> m.tag==="id"?m.o:"X", 
   dst:(m)=> m.tag==="id"?m.o:"Y",
-  comp:(g,f)=>{ 
+  compose:(g,f)=>{ 
     if (C.dst(f)!==C.src(g)) throw new Error("C comp");
     if (f.tag==="id") return g; 
     if (g.tag==="id") return f; 
@@ -36,7 +36,7 @@ const D: SmallCategory<DObj,DM> & HasHom<DObj,DM> & {objects:DObj[]; morphisms:D
   id:(o)=> o==="d0"?{tag:"id0"}:{tag:"id1"},
   src:(m)=> m.tag==="id0"?"d0":m.tag==="id1"?"d1":"d0",
   dst:(m)=> m.tag==="id0"?"d0":m.tag==="id1"?"d1":"d1",
-  comp:(g,f)=>{ 
+  compose:(g,f)=>{ 
     if (D.dst(f)!==D.src(g)) throw new Error("D comp");
     if (f.tag==="id0"||f.tag==="id1") return g;
     if (g.tag==="id0"||g.tag==="id1") return f;
@@ -54,7 +54,7 @@ const Dp: SmallCategory<DpObj,DpM> & HasHom<DpObj,DpM> & {objects:DpObj[]; morph
   id:(o)=> o==="e0"?{tag:"idE0"}:{tag:"idE1"},
   src:(m)=> m.tag==="idE0"?"e0":m.tag==="idE1"?"e1":"e0",
   dst:(m)=> m.tag==="idE0"?"e0":m.tag==="idE1"?"e1":"e1",
-  comp:(g,f)=>{ 
+  compose:(g,f)=>{ 
     if (Dp.dst(f)!==Dp.src(g)) throw new Error("Dp comp");
     if (f.tag==="idE0"||f.tag==="idE1") return g;
     if (g.tag==="idE0"||g.tag==="idE1") return f;

--- a/src/examples/profunctor-calculus-demo.ts
+++ b/src/examples/profunctor-calculus-demo.ts
@@ -124,7 +124,7 @@ const RelDouble = makeRelationsDouble();
 try {
   RelDouble.mkSquare({
     hTop: RelCat().id(set1),
-    hBot: RelCat().comp(conjoint, companion),
+    hBot: RelCat().compose(conjoint, companion),
     vLeft: FuncCat().id(set1),
     vRight: FuncCat().id(set1)
   });
@@ -135,7 +135,7 @@ try {
 
 try {
   RelDouble.mkSquare({
-    hTop: RelCat().comp(companion, conjoint),
+    hTop: RelCat().compose(companion, conjoint),
     hBot: RelCat().id(set2),
     vLeft: FuncCat().id(set2),
     vRight: FuncCat().id(set2)

--- a/src/examples/ran-set-demo.ts
+++ b/src/examples/ran-set-demo.ts
@@ -34,7 +34,7 @@ function runRanSetDemo() {
     id: (o: CObj) => ({ tag: "id", o }),
     src: (m: CM) => m.tag === "id" ? m.o : "X",
     dst: (m: CM) => m.tag === "id" ? m.o : "Y",
-    comp: (g: CM, f: CM) => {
+    compose: (g: CM, f: CM) => {
       if (f.tag === "id") return g;
       if (g.tag === "id") return f;
       return { tag: "u" };
@@ -50,7 +50,7 @@ function runRanSetDemo() {
     id: (_) => ({ tag: "id" }),
     src: (_) => "*",
     dst: (_) => "*",
-    comp: (_g, _f) => ({ tag: "id" }),
+    compose: (_g, _f) => ({ tag: "id" }),
     hom: (_x, _y) => [{ tag: "id" }]
   };
 

--- a/src/types/__tests__/bicategory-coherence.test.ts
+++ b/src/types/__tests__/bicategory-coherence.test.ts
@@ -21,7 +21,7 @@ const A = {
   id: (o: Obj) => o === "X" ? idX : idY,
   src: (m: Mor) => m.src,
   dst: (m: Mor) => m.dst,
-  comp: (g: Mor, f: Mor) => { 
+  compose: (g: Mor, f: Mor) => { 
     if (f.dst !== g.src) throw new Error("composition mismatch");
     if (f.name.startsWith("id")) return g; 
     if (g.name.startsWith("id")) return f; 

--- a/src/types/__tests__/cat2-basic.test.ts
+++ b/src/types/__tests__/cat2-basic.test.ts
@@ -18,7 +18,7 @@ const A: SmallCategory<Obj, Mor> & { objects: Obj[] } = {
   id: (o: Obj) => o === "X" ? idX : idY,
   src: (m: Mor) => m.src,
   dst: (m: Mor) => m.dst,
-  comp: (g: Mor, f: Mor) => { 
+  compose: (g: Mor, f: Mor) => { 
     if (f.dst !== g.src) throw new Error("composition mismatch");
     if (f.name.startsWith("id")) return g; 
     if (g.name.startsWith("id")) return f; 

--- a/src/types/__tests__/codensity-adjunction.test.ts
+++ b/src/types/__tests__/codensity-adjunction.test.ts
@@ -42,7 +42,7 @@ const discreteB = {
   id: (o) => ({ tag: "id", o }),
   src: (m) => m.o,
   dst: (m) => m.o,
-  comp: (g, f) => g.o === f.o ? g : (() => { throw new Error("No morphisms"); })(),
+  compose: (g, f) => g.o === f.o ? g : (() => { throw new Error("No morphisms"); })(),
   hom: (x, y) => x === y ? [{ tag: "id", o: x }] : []
 };
 

--- a/src/types/__tests__/codensity-comma-vs-end.test.ts
+++ b/src/types/__tests__/codensity-comma-vs-end.test.ts
@@ -18,7 +18,7 @@ describe("Codensity by End vs Comma-limit (discrete B sanity)", () => {
     id,
     src: (m: Mor) => m.at,
     dst: (m: Mor) => m.at,
-    comp: (g: Mor, f: Mor) => { 
+    compose: (g: Mor, f: Mor) => { 
       if (g.at !== f.at) throw new Error("discrete: compose only identities"); 
       return id(f.at); 
     },

--- a/src/types/__tests__/codensity-discrete.test.ts
+++ b/src/types/__tests__/codensity-discrete.test.ts
@@ -14,7 +14,7 @@ const createDiscrete2 = () => {
     id: (o: BObj) => ({ tag: "id", o }),
     src: (m: BM) => m.o,
     dst: (m: BM) => m.o,
-    comp: (g: BM, f: BM) => {
+    compose: (g: BM, f: BM) => {
       if (g.o === f.o) return g;
       throw new Error("Cannot compose across different objects in discrete category");
     },
@@ -100,7 +100,7 @@ describe("Codensity for discrete B reduces to product of exponentials", () => {
       id: (_: BObj) => ({ tag: "id" }),
       src: (_: BM) => "*",
       dst: (_: BM) => "*",
-      comp: (_g: BM, _f: BM) => ({ tag: "id" }),
+      compose: (_g: BM, _f: BM) => ({ tag: "id" }),
       hom: (_x: BObj, _y: BObj) => [{ tag: "id" }]
     };
 

--- a/src/types/__tests__/codensity-endX.test.ts
+++ b/src/types/__tests__/codensity-endX.test.ts
@@ -14,7 +14,7 @@ const createTerminalCategory = () => {
     id: (_: BObj) => ({ tag: "id" }),
     src: (_: BM) => "•",
     dst: (_: BM) => "•",
-    comp: (_g: BM, _f: BM) => ({ tag: "id" }),
+    compose: (_g: BM, _f: BM) => ({ tag: "id" }),
     hom: (_x: BObj, _y: BObj) => [{ tag: "id" }]
   };
   

--- a/src/types/__tests__/codensity-ergonomic.test.ts
+++ b/src/types/__tests__/codensity-ergonomic.test.ts
@@ -221,7 +221,7 @@ describe("Ergonomic codensity monad interface (of/map/chain/ap)", () => {
       id: (_: BObj) => ({ tag: "id" }),
       src: (_: BM) => "*",
       dst: (_: BM) => "*",
-      comp: (_g: BM, _f: BM) => ({ tag: "id" }),
+      compose: (_g: BM, _f: BM) => ({ tag: "id" }),
       hom: (_x: BObj, _y: BObj) => [{ tag: "id" }]
     };
 

--- a/src/types/__tests__/codensity-monad.test.ts
+++ b/src/types/__tests__/codensity-monad.test.ts
@@ -16,7 +16,7 @@ const createTerminalCategory = () => {
     id: (_: BObj) => ({ tag: "id" }),
     src: (_: BM) => "b",
     dst: (_: BM) => "b",
-    comp: (_g: BM, _f: BM) => ({ tag: "id" }),
+    compose: (_g: BM, _f: BM) => ({ tag: "id" }),
     hom: (_x: BObj, _y: BObj) => [{ tag: "id" }]
   };
   

--- a/src/types/__tests__/codensity-nat-view.test.ts
+++ b/src/types/__tests__/codensity-nat-view.test.ts
@@ -24,7 +24,7 @@ const createTerminalCategory = () => {
     id: (_: BObj) => ({ tag: "id" }),
     src: (_: BM) => "*",
     dst: (_: BM) => "*",
-    comp: (_g: BM, _f: BM) => ({ tag: "id" })
+    compose: (_g: BM, _f: BM) => ({ tag: "id" })
   };
   
   return Terminal;

--- a/src/types/__tests__/presheaf-colim-transport.test.ts
+++ b/src/types/__tests__/presheaf-colim-transport.test.ts
@@ -21,7 +21,7 @@ const C = {
   id: (o: Obj) => o === "A" ? idA : idB,
   src: (m: Mor) => m.src,
   dst: (m: Mor) => m.dst,
-  comp: (g: Mor, f2: Mor) => { 
+  compose: (g: Mor, f2: Mor) => { 
     if (f2.dst !== g.src) throw new Error("composition mismatch");
     if (f2.name.startsWith("id")) return g; 
     if (g.name.startsWith("id")) return f2; 
@@ -64,7 +64,7 @@ const J = {
   id: (o: JObj) => o === "j1" ? id1 : id2,
   src: (m: JMor) => m.src,
   dst: (m: JMor) => m.dst,
-  comp: (g: JMor, f2: JMor) => { 
+  compose: (g: JMor, f2: JMor) => { 
     if (f2.dst !== g.src) throw new Error("composition mismatch");
     return g; 
   },

--- a/src/types/__tests__/presheaf-colimits-transport.test.ts
+++ b/src/types/__tests__/presheaf-colimits-transport.test.ts
@@ -21,7 +21,7 @@ const C = {
   id: (o: CObj) => o === "A" ? idA : idB,
   src: (f: CMor) => f.src,
   dst: (f: CMor) => f.dst,
-  comp: (g: CMor, f: CMor) => {
+  compose: (g: CMor, f: CMor) => {
     if (f.dst !== g.src) throw new Error("composition mismatch");
     if (f.name.startsWith("id")) return g;
     if (g.name.startsWith("id")) return f;
@@ -50,7 +50,7 @@ const J = {
   id: (o: JObj) => { throw new Error("no morphisms in discrete category"); },
   src: (f: any) => { throw new Error("no morphisms"); },
   dst: (f: any) => { throw new Error("no morphisms"); },
-  comp: (g: any, f: any) => { throw new Error("no morphisms"); },
+  compose: (g: any, f: any) => { throw new Error("no morphisms"); },
   hom: (x: JObj, y: JObj) => ({
     id: `hom-${x}-${y}`,
     elems: x === y ? [] : [], // No non-identity morphisms in discrete category
@@ -121,7 +121,7 @@ describe("Presheaf colimits with correct transport", () => {
       id: (o: any) => { throw new Error("no objects"); },
       src: (m: any) => { throw new Error("no morphisms"); },
       dst: (m: any) => { throw new Error("no morphisms"); },
-      comp: (g: any, f: any) => { throw new Error("no morphisms"); },
+      compose: (g: any, f: any) => { throw new Error("no morphisms"); },
       hom: (x: any, y: any) => ({ id: "empty", elems: [], eq: (a: any, b: any) => false })
     };
     

--- a/src/types/__tests__/presheaf-colimits.test.ts
+++ b/src/types/__tests__/presheaf-colimits.test.ts
@@ -26,7 +26,7 @@ const C = {
   id: (o: Obj) => o === "A" ? idA : idB,
   src: (m: Mor) => m.src,
   dst: (m: Mor) => m.dst,
-  comp: (g: Mor, f: Mor) => { 
+  compose: (g: Mor, f: Mor) => { 
     if (f.dst !== g.src) throw new Error("composition mismatch");
     if (f.name.startsWith("id")) return g; 
     if (g.name.startsWith("id")) return f; 

--- a/src/types/__tests__/presheaf-limit-general.test.ts
+++ b/src/types/__tests__/presheaf-limit-general.test.ts
@@ -21,7 +21,7 @@ const C = {
   id: (o: Obj) => o === "A" ? idA : idB,
   src: (m: Mor) => m.src,
   dst: (m: Mor) => m.dst,
-  comp: (g: Mor, f2: Mor) => { 
+  compose: (g: Mor, f2: Mor) => { 
     if (f2.dst !== g.src) throw new Error("composition mismatch");
     if (f2.name.startsWith("id")) return g; 
     if (g.name.startsWith("id")) return f2; 
@@ -64,7 +64,7 @@ const J = {
   id: (o: JObj) => o === "j1" ? id1 : id2,
   src: (m: JMor) => m.src,
   dst: (m: JMor) => m.dst,
-  comp: (g: JMor, f2: JMor) => { 
+  compose: (g: JMor, f2: JMor) => { 
     if (f2.dst !== g.src) throw new Error("composition mismatch");
     return g; 
   },

--- a/src/types/__tests__/presheaf-pushout-general.test.ts
+++ b/src/types/__tests__/presheaf-pushout-general.test.ts
@@ -21,7 +21,7 @@ const C = {
   id: (o: Obj) => o === "A" ? idA : idB,
   src: (m: Mor) => m.src,
   dst: (m: Mor) => m.dst,
-  comp: (g: Mor, f2: Mor) => { 
+  compose: (g: Mor, f2: Mor) => { 
     if (f2.dst !== g.src) throw new Error("composition mismatch");
     if (f2.name.startsWith("id")) return g; 
     if (g.name.startsWith("id")) return f2; 

--- a/src/types/__tests__/ran-set.test.ts
+++ b/src/types/__tests__/ran-set.test.ts
@@ -24,7 +24,7 @@ describe("Right Kan Extension (RanSet)", () => {
       id: (o: CObj) => ({ tag: "id", o }),
       src: (m: CM) => m.tag === "id" ? m.o : "X",
       dst: (m: CM) => m.tag === "id" ? m.o : "Y",
-      comp: (g: CM, f: CM) => {
+      compose: (g: CM, f: CM) => {
         if (f.tag === "id") return g;
         if (g.tag === "id") return f;
         return { tag: "u" };
@@ -44,7 +44,7 @@ describe("Right Kan Extension (RanSet)", () => {
       id: (_) => ({ tag: "id" }),
       src: (_) => "*",
       dst: (_) => "*",
-      comp: (_g, _f) => ({ tag: "id" }),
+      compose: (_g, _f) => ({ tag: "id" }),
       hom: (_x, _y) => [{ tag: "id" }]
     };
     
@@ -62,7 +62,7 @@ describe("Right Kan Extension (RanSet)", () => {
       id: (o: CObj) => ({ tag: "id", o }),
       src: (m: CM) => m.o,
       dst: (m: CM) => m.o,
-      comp: (g: CM, f: CM) => {
+      compose: (g: CM, f: CM) => {
         if (g.o === f.o) return g;
         throw new Error("Cannot compose morphisms in discrete category");
       }

--- a/src/types/category-to-nerve-sset.ts
+++ b/src/types/category-to-nerve-sset.ts
@@ -76,9 +76,9 @@ export function checkFunctorLaws<C_O, C_M, D_O, D_M>(
   const preservesComp = samples.every(m => {
     // try composing with an identity on either side as a lightweight check
     const x = C.src(m);
-    const lhs = F.Fmor(C.comp(m, C.id(x))); // m ∘ id_x = m
+    const lhs = F.Fmor(C.compose(m, C.id(x))); // m ∘ id_x = m
     const rhs = F.Fmor(m);
-    const lhsD = D.comp(F.Fmor(m), F.Fmor(C.id(x))); // F m ∘ F id_x
+    const lhsD = D.compose(F.Fmor(m), F.Fmor(C.id(x))); // F m ∘ F id_x
     const eq = eqJSON<unknown>();
     return eq(D.src(lhs), D.src(rhs)) && eq(D.dst(lhs), D.dst(rhs)) &&
            eq(D.src(lhsD), D.src(rhs)) && eq(D.dst(lhsD), D.dst(rhs));
@@ -97,8 +97,8 @@ export function checkNaturality<C_O, C_M, D_O, D_M>(
   // For each m: x→y, G(m) ∘ η_x = η_y ∘ F(m)
   return samples.every(m => {
     const x = C.src(m), y = C.dst(m);
-    const left  = D.comp(G.Fmor(m), eta.eta(x));
-    const right = D.comp(eta.eta(y), F.Fmor(m));
+    const left  = D.compose(G.Fmor(m), eta.eta(x));
+    const right = D.compose(eta.eta(y), F.Fmor(m));
     const eq = eqJSON<unknown>();
     return eq(D.src(left), D.src(right)) && eq(D.dst(left), D.dst(right));
   });
@@ -163,7 +163,7 @@ export function Nerve<O, M>(C: SmallCategory<O, M>): SimplicialSet<O, M> {
     }
     // compose fi+1 ∘ fi at position i-1
     const before = s.chain.slice(0, i - 1);
-    const mid = C.comp(s.chain[i]!, s.chain[i - 1]!);
+    const mid = C.compose(s.chain[i]!, s.chain[i - 1]!);
     const after = s.chain.slice(i + 1);
     return { head: s.head, chain: [...before, mid, ...after] };
   };
@@ -265,7 +265,7 @@ export function compose1From1<O, M>(
   m2: M  // y→z
 ): NSimplex<O, M> {
   if (C.dst(m1) !== C.src(m2)) throw new Error(`compose1From1: morphisms not composable`);
-  const comp = C.comp(m2, m1); // m2 ∘ m1 : x→z
+  const comp = C.compose(m2, m1); // m2 ∘ m1 : x→z
   const head = C.src(m1);
   return { head, chain: [comp] };
 }
@@ -276,7 +276,7 @@ export function compose1From2<O, M>(
   s: NSimplex<O, M>
 ): NSimplex<O, M> {
   if (s.chain.length !== 2) throw new Error(`compose1From2: expected a 2-simplex`);
-  const comp = C.comp(s.chain[1]!, s.chain[0]!);
+  const comp = C.compose(s.chain[1]!, s.chain[0]!);
   return { head: s.head, chain: [comp] };
 }
 
@@ -472,7 +472,7 @@ export function d1_of_2simplex<O, M>(
   s: NSimplex<O, M>
 ): NSimplex<O, M> {
   if (s.chain.length !== 2) throw new Error("d1_of_2simplex: expected a 2-simplex");
-  const comp = C.comp(s.chain[1]!, s.chain[0]!);
+  const comp = C.compose(s.chain[1]!, s.chain[0]!);
   return { head: s.head, chain: [comp] };
 }
 
@@ -499,7 +499,7 @@ export function checkFilledHorn2<O, M>(
     })();
 
   const compFace = d1_of_2simplex(C, filler);
-  const expectedComp = C.comp(horn.d0.chain[0]!, horn.d2.chain[0]!); // m12∘m01
+  const expectedComp = C.compose(horn.d0.chain[0]!, horn.d2.chain[0]!); // m12∘m01
   const compOk = compFace.chain[0] === expectedComp && compFace.head === horn.d2.head;
   return okFaces && compOk;
 }
@@ -571,8 +571,8 @@ export function makeCommutingSquaresDouble<O, M>(
   };
 
   const commuteCheck = (b: Square<O, M, M>) => {
-    const topThenRight = C.comp(b.vRight, b.hTop);
-    const leftThenBot  = C.comp(b.hBot,  b.vLeft);
+    const topThenRight = C.compose(b.vRight, b.hTop);
+    const leftThenBot  = C.compose(b.hBot,  b.vLeft);
     if (!eqM(topThenRight, leftThenBot)) {
       throw new Error("Square does not commute: vRight ∘ hTop ≠ hBot ∘ vLeft");
     }
@@ -596,8 +596,8 @@ export function makeCommutingSquaresDouble<O, M>(
     if (C.dst(alpha.vRight) !== C.src(beta.vLeft))
       throw new Error("hcomp: alpha.vRight must equal beta.vLeft (same object boundary)");
 
-    const hTop = C.comp(beta.hTop, alpha.hTop);
-    const hBot = C.comp(beta.hBot, alpha.hBot);
+    const hTop = C.compose(beta.hTop, alpha.hTop);
+    const hBot = C.compose(beta.hBot, alpha.hBot);
     const vLeft  = alpha.vLeft;
     const vRight = beta.vRight;
 
@@ -613,8 +613,8 @@ export function makeCommutingSquaresDouble<O, M>(
 
     const hTop = alpha.hTop;
     const hBot = beta.hBot;
-    const vLeft  = C.comp(beta.vLeft,  alpha.vLeft);
-    const vRight = C.comp(beta.vRight, alpha.vRight);
+    const vLeft  = C.compose(beta.vLeft,  alpha.vLeft);
+    const vRight = C.compose(beta.vRight, alpha.vRight);
 
     return mkSquare({ hTop, hBot, vLeft, vRight });
   };
@@ -840,13 +840,13 @@ export const conjointOf = (f: FnM): Rel => ({
 export function unitSquare(D = makeRelationsDouble(), f: FnM) {
   const H = RelCat(), V = FuncCat();
   const etaTop  = H.id(f.src);                                  // id_A
-  const etaBot  = H.comp(conjointOf(f), companionOf(f));         // Γ_f^† ∘ Γ_f
+  const etaBot  = H.compose(conjointOf(f), companionOf(f));         // Γ_f^† ∘ Γ_f
   return D.mkSquare({ hTop: etaTop, hBot: etaBot, vLeft: V.id(f.src), vRight: V.id(f.src) });
 }
 
 export function counitSquare(D = makeRelationsDouble(), f: FnM) {
   const H = RelCat(), V = FuncCat();
-  const epsTop = H.comp(companionOf(f), conjointOf(f));          // Γ_f ∘ Γ_f^†
+  const epsTop = H.compose(companionOf(f), conjointOf(f));          // Γ_f ∘ Γ_f^†
   const epsBot = H.id(f.dst);                                    // id_B
   return D.mkSquare({ hTop: epsTop, hBot: epsBot, vLeft: V.id(f.dst), vRight: V.id(f.dst) });
 }
@@ -856,8 +856,8 @@ export function trianglesHold(f: FnM): boolean {
   const H = RelCat();
   const G  = companionOf(f);   // A↔B
   const Gd = conjointOf(f);    // B↔A
-  const leftTriangle  = H.comp(H.comp(G, Gd), G);   // (Γ ∘ Γ†) ∘ Γ
-  const rightTriangle = H.comp(Gd, H.comp(G, Gd));  // Γ† ∘ (Γ ∘ Γ†)
+  const leftTriangle  = H.compose(H.compose(G, Gd), G);   // (Γ ∘ Γ†) ∘ Γ
+  const rightTriangle = H.compose(Gd, H.compose(G, Gd));  // Γ† ∘ (Γ ∘ Γ†)
   return equalRel(leftTriangle, G) && equalRel(rightTriangle, Gd);
 }
 
@@ -892,8 +892,8 @@ export function makeRelationsDouble() {
 
   const hcomp = (beta: Square<SetObj<any>,Rel,FnM>, alpha: Square<SetObj<any>,Rel,FnM>) =>
     mkSquare({
-      hTop: H.comp(beta.hTop, alpha.hTop),
-      hBot: H.comp(beta.hBot, alpha.hBot),
+      hTop: H.compose(beta.hTop, alpha.hTop),
+      hBot: H.compose(beta.hBot, alpha.hBot),
       vLeft: alpha.vLeft,
       vRight: beta.vRight
     });
@@ -902,8 +902,8 @@ export function makeRelationsDouble() {
     mkSquare({
       hTop: alpha.hTop,
       hBot: beta.hBot,
-      vLeft: V.comp(beta.vLeft, alpha.vLeft),
-      vRight: V.comp(beta.vRight, alpha.vRight)
+      vLeft: V.compose(beta.vLeft, alpha.vLeft),
+      vRight: V.compose(beta.vRight, alpha.vRight)
     });
 
   const idVCell = (h: Rel) => mkSquare({

--- a/src/types/catkit-adjunction.ts
+++ b/src/types/catkit-adjunction.ts
@@ -52,8 +52,8 @@ export function checkNaturality<A_O, A_M, B_O, B_M>(
   const { F, G, at } = nt;
   return A.morphisms.every(u => {
     const a  = A.src(u), a2 = A.dst(u);
-    const lhs = B.comp(G.Fmor(u), at(a));
-    const rhs = B.comp(at(a2),    F.Fmor(u));
+    const lhs = B.compose(G.Fmor(u), at(a));
+    const rhs = B.compose(at(a2),    F.Fmor(u));
     const eq = eqJSON<any>();
     return eq(lhs, rhs);
   });
@@ -79,7 +79,7 @@ export function checkAdjunctionTriangles<A_O, A_M, B_O, B_M>(Adj: Adjunction<A_O
   // (1) for each a in A, compare in B
   const ok1 = (A as any).objects
     ? (A as any).objects.every((a: A_O) => {
-        const left  = B.comp(counit.at(F.Fobj(a)), F.Fmor(unit.at(a)));
+        const left  = B.compose(counit.at(F.Fobj(a)), F.Fmor(unit.at(a)));
         const right = B.id(F.Fobj(a));
         const eq = eqJSON<any>();
         return eq(left, right);
@@ -89,7 +89,7 @@ export function checkAdjunctionTriangles<A_O, A_M, B_O, B_M>(Adj: Adjunction<A_O
   // (2) for each b in B, compare in A
   const ok2 = (B as any).objects
     ? (B as any).objects.every((b: B_O) => {
-        const left  = A.comp(G.Fmor(counit.at(b)), unit.at(G.Fobj(b)));
+        const left  = A.compose(G.Fmor(counit.at(b)), unit.at(G.Fobj(b)));
         const right = A.id(G.Fobj(b));
         const eq = eqJSON<any>();
         return eq(left, right);
@@ -123,8 +123,8 @@ export function companionHomProf<A_O, A_M, B_O, B_M>(
 ): FiniteProf<A_O, A_M, B_O, B_M, B_M> {
   return {
     elems: (a, b) => B.hom(F.Fobj(a), b),
-    lmap:  (u, b, m) => B.comp(m, F.Fmor(u)),
-    rmap:  (_a, v, m) => B.comp(v, m),
+    lmap:  (u, b, m) => B.compose(m, F.Fmor(u)),
+    rmap:  (_a, v, m) => B.compose(v, m),
     keyT: (m) => String(m),
     eqT: eqJSON<B_M>()
   };
@@ -137,8 +137,8 @@ export function conjointHomProf<A_O, A_M, B_O, B_M>(
 ): FiniteProf<A_O, A_M, B_O, B_M, B_M> {
   return {
     elems: (a, b) => B.hom(b, F.Fobj(a)),
-    lmap:  (u, b, m) => B.comp(F.Fmor(u), m), // precompose in codomain of m
-    rmap:  (_a, v, m) => B.comp(m, v),       // postcompose
+    lmap:  (u, b, m) => B.compose(F.Fmor(u), m), // precompose in codomain of m
+    rmap:  (_a, v, m) => B.compose(m, v),       // postcompose
     keyT: (m) => String(m),
     eqT: eqJSON<B_M>()
   };
@@ -164,7 +164,7 @@ export function mateLeftToRight<X_O, X_M, A_O, A_M, B_O, B_M>(
     at: (x: X_O) => {
       const eta = unit.at(H.Fobj(x));            // Hx → G(F(Hx))
       const Galpha = G.Fmor(alpha.at(x));        // G(F(Hx)) → G(Kx)
-      return A.comp(Galpha, eta);                // G(α_x) ∘ η_{Hx}
+      return A.compose(Galpha, eta);                // G(α_x) ∘ η_{Hx}
     }
   };
 }
@@ -186,7 +186,7 @@ export function mateRightToLeft<X_O, X_M, A_O, A_M, B_O, B_M>(
     at: (x: X_O) => {
       const Fbeta = F.Fmor(beta.at(x));          // F(Hx) → F(GKx)
       const eps   = counit.at(K.Fobj(x));        // F(GKx) → Kx
-      return B.comp(eps, Fbeta);                 // ε_{Kx} ∘ F(β_x)
+      return B.compose(eps, Fbeta);                 // ε_{Kx} ∘ F(β_x)
     }
   };
 }

--- a/src/types/catkit-equivalence.ts
+++ b/src/types/catkit-equivalence.ts
@@ -42,8 +42,8 @@ export function checkNaturality<A_O,A_M,B_O,B_M>(
   const { F,G,at } = nt;
   return A.morphisms.every(u => {
     const a  = A.src(u), a2 = A.dst(u);
-    const lhs = B.comp(G.Fmor(u), at(a));
-    const rhs = B.comp(at(a2),    F.Fmor(u));
+    const lhs = B.compose(G.Fmor(u), at(a));
+    const rhs = B.compose(at(a2),    F.Fmor(u));
     const eq = eqJSON<any>();
     return eq(lhs, rhs);
   });
@@ -57,9 +57,9 @@ export interface Iso<O,M> {
 }
 export function checkIso<O,M>(iso: Iso<O,M>): boolean {
   const { C,a,b,f,g } = iso;
-  const left  = C.comp(g,f);
+  const left  = C.compose(g,f);
   const right = C.id(a);
-  const left2 = C.comp(f,g);
+  const left2 = C.compose(f,g);
   const right2= C.id(b);
   const eq = eqJSON<any>();
   return eq(left, right) && eq(left2, right2);
@@ -79,8 +79,8 @@ export function composeNatIso<A_O,A_M,B_O,B_M>(
   return {
     F: alpha.F,
     G: beta.G,
-    at:   (a:A_O)=> B.comp(beta.at(a), alpha.at(a)),
-    invAt:(a:A_O)=> B.comp(alpha.invAt(a), beta.invAt(a))
+    at:   (a:A_O)=> B.compose(beta.at(a), alpha.at(a)),
+    invAt:(a:A_O)=> B.compose(alpha.invAt(a), beta.invAt(a))
   };
 }
 export function invertNatIso<A_O,A_M,B_O,B_M>(alpha: NatIso<A_O,A_M,B_O,B_M>): NatIso<A_O,A_M,B_O,B_M> {
@@ -95,9 +95,9 @@ export function checkNatIso<A_O,A_M,B_O,B_M>(
   const nat = checkNaturality(A,B,alpha);
   const pointwise = (A.objects as A_O[]).every(a => {
     const f = alpha.at(a), g = alpha.invAt(a);
-    const left  = B.comp(g,f);
+    const left  = B.compose(g,f);
     const right = B.id(alpha.F.Fobj(a));
-    const left2 = B.comp(f,g);
+    const left2 = B.compose(f,g);
     const right2= B.id(alpha.G.Fobj(a));
     const eq = eqJSON<any>();
     return eq(left, right) && eq(left2, right2);
@@ -120,14 +120,14 @@ export function checkAdjointEquivalence<A_O,A_M,B_O,B_M>(E: AdjointEquivalence<A
   const cIso = checkNatIso(B,B,counit);
   const ok1 = (A.objects as A_O[]).every(a => {
     const Fa = F.Fobj(a);
-    const left  = B.comp(counit.at(Fa), F.Fmor(unit.at(a)));
+    const left  = B.compose(counit.at(Fa), F.Fmor(unit.at(a)));
     const right = B.id(Fa);
     const eq = eqJSON<any>();
     return eq(left, right);
   });
   const ok2 = (B.objects as B_O[]).every(b => {
     const Gb = G.Fobj(b);
-    const left  = A.comp(G.Fmor(counit.at(b)), unit.at(Gb));
+    const left  = A.compose(G.Fmor(counit.at(b)), unit.at(Gb));
     const right = A.id(Gb);
     const eq = eqJSON<any>();
     return eq(left, right);
@@ -147,10 +147,10 @@ export function homIsoViaEquivalence<A_O,A_M,B_O,B_M>(
     const Fa2 = F.Fobj(a2);
     const unitA = unit.at(a);
     // Use type assertion to avoid complex type checking
-    return B.comp(B.comp(counit.at(Fa2), Fh), unitA as any) as B_M;
+    return B.compose(B.compose(counit.at(Fa2), Fh), unitA as any) as B_M;
   };
   const invUnitAtA = unit.invAt(a);
-  const toA = (k:B_M) => A.comp( G.Fmor(k), invUnitAtA );
+  const toA = (k:B_M) => A.compose( G.Fmor(k), invUnitAtA );
   return { toB, toA };
 }
 

--- a/src/types/catkit-kan-transport-fixed.ts
+++ b/src/types/catkit-kan-transport-fixed.ts
@@ -132,7 +132,7 @@ export function transportRightKanAlongEquivalenceFixed<C_O,C_M,D_O,D_M,Dp_O,Dp_M
         // FIXED: Consistent key space usage
         for (const g of D.hom(E.G.Fobj(dP), F.Fobj(c))) {
           const Kg   = E.F.Fmor(g);               // K(g) : K(G d') → K(F c)
-          const hP   = Dp.comp(Kg, epsInv);       // d' → K(F c)
+          const hP   = Dp.compose(Kg, epsInv);       // d' → K(F c)
           const keyH_D_prime = keyDMorP(hP);      // FIXED: Use consistent key space
           const keyG_D = keyDMor(g);              // Key in D space
           
@@ -161,7 +161,7 @@ export function transportRightKanAlongEquivalenceFixed<C_O,C_M,D_O,D_M,Dp_O,Dp_M
         // FIXED: Consistent key space usage
         for (const h of Dp.hom(dP, E.F.Fobj(F.Fobj(c)))) {
           const Gh   = E.G.Fmor(h);                 // G(h): G d' → G K F c
-          const g    = D.comp(etaInvFc, Gh);        // G d' → F c
+          const g    = D.compose(etaInvFc, Gh);        // G d' → F c
           const keyH_D_prime = keyDMorP(h);         // Key in D' space
           const keyG_D = keyDMor(g);                // Key in D space
           
@@ -383,7 +383,7 @@ function classifyLeftKan<C_O, C_M, D_O, D_M>(
     const c = C.src(u) as C_O, cp = C.dst(u) as C_O;
     const Hu = H.map(u);
     for (const h of D.hom(F.Fobj(cp), d)) {
-      const f1 = D.comp(h, F.Fmor(u));
+      const f1 = D.compose(h, F.Fmor(u));
       for (const x of H.obj(c).elems) {
         const x2 = Hu(x);
         const kL = `${keyC(c)}|f=${keyDMor(f1)}|x=${keyFromValue(x)}`;

--- a/src/types/catkit-kan-transport.ts
+++ b/src/types/catkit-kan-transport.ts
@@ -111,7 +111,7 @@ function classifyLeftKan<C_O, C_M, D_O, D_M>(
     const c = C.src(u) as C_O, cp = C.dst(u) as C_O;
     const Hu = H.map(u);
     for (const h of D.hom(F.Fobj(cp), d)) {
-      const f1 = D.comp(h, F.Fmor(u));
+      const f1 = D.compose(h, F.Fmor(u));
       for (const x of H.obj(c).elems) {
         const x2 = Hu(x);
         const kL = `${keyC(c)}|f=${keyDMor(f1)}|x=${keyFromValue(x)}`;
@@ -161,7 +161,7 @@ export function transportLeftKanAlongEquivalence<C_O,C_M,D_O,D_M,Dp_O,Dp_M>(
       // map f' : K(Fc)→d'  to  f : Fc → G(d')
       const f_in_D = E.G.Fmor(fp);               // G(f') : G(K Fc) → G(d')
       const etaFc  = E.unit.at(F.Fobj(c));       // Fc → G(K Fc)
-      const f = D.comp(f_in_D, etaFc);           // Fc → G(d')
+      const f = D.compose(f_in_D, etaFc);           // Fc → G(d')
       return classifyD.normalize({ c, f, x });
     };
   };
@@ -174,7 +174,7 @@ export function transportLeftKanAlongEquivalence<C_O,C_M,D_O,D_M,Dp_O,Dp_M>(
       // map f : Fc → G(d')  to  f' : K(Fc) → d'
       const Kf  = E.F.Fmor(f);            // K(f) : K(Fc) → K(G d')
       const eps = E.counit.at(dP);        // ε_{d'} : K(G d') → d'
-      const fp  = Dp.comp(eps, Kf);       // K(Fc) → d'
+      const fp  = Dp.compose(eps, Kf);       // K(Fc) → d'
       return classifyDp.normalize({ c, f: fp, x });
     };
   };
@@ -216,7 +216,7 @@ export function transportRightKanAlongEquivalence<C_O,C_M,D_O,D_M,Dp_O,Dp_M>(
         // For each g : G d' → F c in D, compute h' = ε^{-1}_{d'} ∘ K(g)
         for (const g of D.hom(E.G.Fobj(dP), F.Fobj(c))) {
           const Kg   = E.F.Fmor(g);               // K(g) : K(G d') → K(F c)
-          const hP   = Dp.comp(Kg, epsInv);       // d' → K(F c)
+          const hP   = Dp.compose(Kg, epsInv);       // d' → K(F c)
           const keyH = keyDMorP(hP);
           mOut.set(keyDMor(g), alphaP.get(keyH));
         }
@@ -239,7 +239,7 @@ export function transportRightKanAlongEquivalence<C_O,C_M,D_O,D_M,Dp_O,Dp_M>(
         const etaInvFc = E.unit.invAt(F.Fobj(c));  // G(K(F c)) → F c
         for (const h of Dp.hom(dP, E.F.Fobj(F.Fobj(c)))) {
           const Gh   = E.G.Fmor(h);                 // G(h): G d' → G K F c
-          const g    = D.comp(etaInvFc, Gh);        // G d' → F c
+          const g    = D.compose(etaInvFc, Gh);        // G d' → F c
           mOut.set(keyDMorP(h), alpha.get(keyDMor(g)));
         }
         out[kc] = mOut;

--- a/src/types/catkit-kan.ts
+++ b/src/types/catkit-kan.ts
@@ -75,7 +75,7 @@ export function LeftKan_Set<C_O, C_M, D_O, D_M>(
       const cp = C.dst(u) as C_O;
       const Hu = H.map(u);
       for (const h of D.hom(F.Fobj(cp), d)) {
-        const f1 = D.comp(h, F.Fmor(u)); // F(u): Fc→Fcp;  h∘F(u): Fc→d
+        const f1 = D.compose(h, F.Fmor(u)); // F(u): Fc→Fcp;  h∘F(u): Fc→d
         const Huxs = H.obj(c).elems.map(x => ({ x, x2: Hu(x) }));
         for (const {x, x2} of Huxs) {
           const kLeft  = `${keyC(c)}|f=${keyDMor(f1)}|x=${keyFromValue(x)}`;
@@ -111,7 +111,7 @@ export function LeftKan_Set<C_O, C_M, D_O, D_M>(
     const dprime = D.dst(v);
     const { normalize } = buildUF(dprime);
     const { c, f, x } = cls.rep;
-    return normalize({ c, f: D.comp(v, f), x });
+    return normalize({ c, f: D.compose(v, f), x });
   };
 
   return { obj, map };
@@ -196,7 +196,7 @@ export function RightKan_Set<C_O, C_M, D_O, D_M>(
         // For every g: d→F c, we need H(u)(α_c(g)) = α_{c'}(F(u)∘g)
         for (const g of D.hom(d, F.Fobj(c))) {
           const left  = Hu(alpha_c.get(keyDMor(g)));
-          const right = alpha_cp.get(keyDMor( D.comp(F.Fmor(u), g) ));
+          const right = alpha_cp.get(keyDMor( D.compose(F.Fmor(u), g) ));
           const eq = eqJSON<unknown>();
           if (!eq(left, right)) return false;
         }
@@ -227,7 +227,7 @@ export function RightKan_Set<C_O, C_M, D_O, D_M>(
       out.__dom = D.hom(dprime, F.Fobj(c));
       out.__cod = H.obj(c).elems;
       for (const g of out.__dom) {
-        const gv = D.comp(g, v); // g ∘ v : d → F c
+        const gv = D.compose(g, v); // g ∘ v : d → F c
         out.set(keyDMor(g), alpha_c.get(keyDMor(gv)));
       }
       result[keyc] = out;


### PR DESCRIPTION
Refactor category composition calls from `.comp()` to `.compose()` to standardize naming conventions across the codebase.

---
<a href="https://cursor.com/background-agent?bcId=bc-87214c90-a604-40de-b0d9-259ee4bb9c05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-87214c90-a604-40de-b0d9-259ee4bb9c05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

