### PR TITLE
Rename ring equality type alias

### DIFF
--- a/src/category/Nat.ts
+++ b/src/category/Nat.ts
@@ -10,3 +10,6 @@ export type Nat<F, G> = <A>(fa: F) => G;
 
 // Simpler alias for natural transformations
 export type Nat1<F, G> = <A>(fa: F) => G;
+
+// NOTE: This is a simplified encoding for TS. In a true HKT setting, you'd have
+// Nat<F,G> = ∀A. F<A> -> G<A>. We erase <A> at the type level and rely on discipline in callers.

--- a/src/structures/group/Grp.ts
+++ b/src/structures/group/Grp.ts
@@ -1,6 +1,6 @@
 import type { FiniteGroup } from "./Group";
 import {
-  GroupHom, hom, idHom, comp,
+  GroupHom, hom, idHom, compose,
   productGroup, proj1, proj2, pairIntoProduct
 } from "./GrpCat";
 
@@ -11,7 +11,7 @@ export type Mor<A,B> = GroupHom<A,B>;
 /** Category structure (just enough for tests) */
 export const Grp = {
   id: idHom,
-  comp,
+  comp: compose,
 
   /** Categorical product data */
   product<A,B>(G: Obj<A>, H: Obj<B>) {

--- a/src/structures/group/GrpCat.ts
+++ b/src/structures/group/GrpCat.ts
@@ -1,26 +1,13 @@
 import type { FiniteGroup } from "./Group";
+import { GroupHom, hom } from "./Hom";
+import { productGroupTuples as productGroup, proj1 as _proj1, proj2 as _proj2, pairIntoProduct as _pairIntoProduct } from "./builders/Product";
 
-/** Group homomorphism */
-export interface GroupHom<A, B> {
-  source: FiniteGroup<A>;
-  target: FiniteGroup<B>;
-  f: (a: A) => B;
-  verify?(): boolean;
-}
+// Re-export the homomorphism types and functions for backward compatibility
+export { GroupHom, hom, productGroup };
 
-// Factory to build a well-typed homomorphism object.
-export function hom<A, B>(
-  source: FiniteGroup<A>,
-  target: FiniteGroup<B>,
-  f: (a: A) => B,
-  verify?: () => boolean
-): GroupHom<A, B> {
-  const result: GroupHom<A, B> = { source, target, f };
-  if (verify !== undefined) {
-    result.verify = verify;
-  }
-  return result;
-}
+export const proj1 = _proj1;
+export const proj2 = _proj2;
+export const pairIntoProduct = _pairIntoProduct;
 
 /** Identity homomorphism */
 export function idHom<A>(G: FiniteGroup<A>): GroupHom<A, A> {
@@ -40,52 +27,7 @@ export function comp<A, B, C>(
   );
 }
 
-/** Product group G × H */
-export function productGroup<A, B>(
-  G: FiniteGroup<A>, 
-  H: FiniteGroup<B>
-): FiniteGroup<[A, B]> {
-  const elems: [A, B][] = [];
-  for (const a of G.elems) {
-    for (const b of H.elems) {
-      elems.push([a, b]);
-    }
-  }
-  
-  return {
-    elems,
-    eq: ([a1, b1], [a2, b2]) => G.eq(a1, a2) && H.eq(b1, b2),
-    op: ([a1, b1], [a2, b2]) => [G.op(a1, a2), H.op(b1, b2)],
-    id: [G.id, H.id],
-    inv: ([a, b]) => [G.inv(a), H.inv(b)]
-  };
-}
 
-/** Projection π1: G × H → G */
-export function proj1<A, B>(G: FiniteGroup<A>, H: FiniteGroup<B>): GroupHom<[A, B], A> {
-  return hom(productGroup(G, H), G, ([a, b]) => a, () => true);
-}
-
-/** Projection π2: G × H → H */
-export function proj2<A, B>(G: FiniteGroup<A>, H: FiniteGroup<B>): GroupHom<[A, B], B> {
-  return hom(productGroup(G, H), H, ([a, b]) => b, () => true);
-}
-
-/** Pair into product: K → G × H given K → G and K → H */
-export function pairIntoProduct<K, A, B>(
-  K: FiniteGroup<K>,
-  G: FiniteGroup<A>,
-  H: FiniteGroup<B>,
-  u: GroupHom<K, A>,
-  v: GroupHom<K, B>
-): GroupHom<K, [A, B]> {
-  return hom(
-    K,
-    productGroup(G, H),
-    (k) => [u.f(k), v.f(k)],
-    () => (u.verify?.() ?? true) && (v.verify?.() ?? true)
-  );
-}
 
 import { trivial } from "./Group";
 

--- a/src/structures/group/GrpCat.ts
+++ b/src/structures/group/GrpCat.ts
@@ -15,7 +15,7 @@ export function idHom<A>(G: FiniteGroup<A>): GroupHom<A, A> {
 }
 
 /** Composition of homomorphisms */
-export function comp<A, B, C>(
+export function compose<A, B, C>(
   f: GroupHom<A, B>, 
   g: GroupHom<B, C>
 ): GroupHom<A, C> {
@@ -26,6 +26,9 @@ export function comp<A, B, C>(
     () => (f.verify?.() ?? true) && (g.verify?.() ?? true)
   );
 }
+
+// Back-compat alias (TODO deprecate and remove after callers are migrated)
+export const comp = compose;
 
 
 

--- a/src/structures/group/Hom.ts
+++ b/src/structures/group/Hom.ts
@@ -1,0 +1,23 @@
+import type { FiniteGroup } from "./Group";
+
+/** Group homomorphism */
+export interface GroupHom<A, B> {
+  source: FiniteGroup<A>;
+  target: FiniteGroup<B>;
+  f: (a: A) => B;
+  verify?(): boolean;
+}
+
+// Factory to build a well-typed homomorphism object.
+export function hom<A, B>(
+  source: FiniteGroup<A>,
+  target: FiniteGroup<B>,
+  f: (a: A) => B,
+  verify?: () => boolean
+): GroupHom<A, B> {
+  const result: GroupHom<A, B> = { source, target, f };
+  if (verify !== undefined) {
+    result.verify = verify;
+  }
+  return result;
+}

--- a/src/structures/group/Isomorphism.ts
+++ b/src/structures/group/Isomorphism.ts
@@ -1,5 +1,5 @@
 import { FiniteGroup } from "./Group";
-import { GroupHom } from "./GrpCat";
+import { GroupHom } from "./Hom";
 import { must, idx } from "../../util/guards";
 
 /** Subgroup inclusion ι : H ↪ G (carriers share the same A; H.elems ⊆ G.elems). */

--- a/src/structures/group/Isomorphism.ts
+++ b/src/structures/group/Isomorphism.ts
@@ -14,8 +14,8 @@ export function inclusion<A>(H: FiniteGroup<A>, G: FiniteGroup<A>): GroupHom<A,A
     f: (h: A) => h,               // identity on the underlying carrier
     verify: () => {
       for (const x of H.elems) for (const y of H.elems) {
-        const left  = inclusion(H,G).f(H.op(x,y));
-        const right = G.op(inclusion(H,G).f(x), inclusion(H,G).f(y));
+        const left  = H.op(x,y);   // because f is identity on the carrier
+        const right = G.op(x,y);
         if (!G.eq(left, right)) return false;
       }
       return true;

--- a/src/structures/group/Quotient.ts
+++ b/src/structures/group/Quotient.ts
@@ -25,6 +25,11 @@ export function leftCosets<A>(
   G: FiniteGroup<A>,
   N: FiniteGroup<A>,
 ): Coset<A>[] {
+  // Fast bail-out for trivial subgroup (cosets are all singletons)
+  if (N.elems.length === 1) {
+    return G.elems.map(rep => ({ rep }));
+  }
+
   const seen: A[] = [];
   const res: Coset<A>[] = [];
   const inSeen = (a: A) => seen.some(s => G.eq(s, a));

--- a/src/structures/group/__tests__/hom.category.laws.test.ts
+++ b/src/structures/group/__tests__/hom.category.laws.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Zn } from "../Group";
-import { hom, idHom, comp } from "../GrpCat";
+import { hom, idHom, compose } from "../GrpCat";
 
 describe("Grp: hom composition laws", () => {
   it("composition, identity, associativity", () => {
@@ -11,16 +11,16 @@ describe("Grp: hom composition laws", () => {
     const h = hom(Z2, Z2, x => x);
 
     // (2) associativity
-    const hComposeG = comp(g,h);        // Z3→Z2
-    const gComposeF = comp(f,g);        // Z6→Z2
-    const lhs = comp(gComposeF, h);     // h ∘ (g ∘ f)
-    const rhs = comp(f, hComposeG);     // (h ∘ g) ∘ f
+    const hComposeG = compose(g,h);        // Z3→Z2
+    const gComposeF = compose(f,g);        // Z6→Z2
+    const lhs = compose(gComposeF, h);     // h ∘ (g ∘ f)
+    const rhs = compose(f, hComposeG);     // (h ∘ g) ∘ f
     for (const x of Z6.elems) expect(Z2.eq(lhs.f(x), rhs.f(x))).toBe(true);
 
     // (3) identities
     const idZ6 = idHom(Z6), idZ3 = idHom(Z3);
-    const f1 = comp(idZ6, f);
-    const f2 = comp(f, idZ3);
+    const f1 = compose(idZ6, f);
+    const f2 = compose(f, idZ3);
     for (const x of Z6.elems) expect(Z3.eq(f1.f(x), f.f(x))).toBe(true);
     for (const x of Z6.elems) expect(Z3.eq(f2.f(x), f.f(x))).toBe(true);
   });

--- a/src/structures/group/__tests__/product_universal_property.test.ts
+++ b/src/structures/group/__tests__/product_universal_property.test.ts
@@ -4,7 +4,7 @@ import { tupleScheme } from "../pairing/PairingScheme";
 import { productGroup } from "../builders/Product";
 import { projections, pairHom } from "../builders/ProductUP";
 import { homEqByPoints } from "../cat/GroupCat";
-import { GroupHom } from "../GrpCat";
+import { GroupHom } from "../Hom";
 import { isHom } from "../Isomorphism";
 
 // Helper to check if a GroupHom object is a valid homomorphism

--- a/src/structures/group/__tests__/product_universal_property_laws.test.ts
+++ b/src/structures/group/__tests__/product_universal_property_laws.test.ts
@@ -3,7 +3,7 @@ import { Z2, Z3, Zn } from "../util/FiniteGroups";
 import { tupleScheme } from "../pairing/PairingScheme";
 import { productGroup } from "../builders/Product";
 import { projections, pairHom } from "../builders/ProductUP";
-import { verifyProductUP, comp, homEqByPoints } from "../cat/GroupCat";
+import { verifyProductUP, compose, homEqByPoints } from "../cat/GroupCat";
 
 describe("Categorical product laws: π, ⟨f,g⟩, uniqueness", () => {
   const G = Z2, H = Z3;
@@ -25,7 +25,7 @@ describe("Categorical product laws: π, ⟨f,g⟩, uniqueness", () => {
     expect(homEqByPoints(h, mediating)).toBe(true);
 
     // sanity: composing with projections recovers f and g
-    expect(homEqByPoints(comp(mediating, pi1), f)).toBe(true);
-    expect(homEqByPoints(comp(mediating, pi2), g)).toBe(true);
+    expect(homEqByPoints(compose(mediating, pi1), f)).toBe(true);
+    expect(homEqByPoints(compose(mediating, pi2), g)).toBe(true);
   });
 });

--- a/src/structures/group/__tests__/theorem2_and_examples.test.ts
+++ b/src/structures/group/__tests__/theorem2_and_examples.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Zn } from "../Group";
-import { hom, idHom, comp } from "../GrpCat";
+import { hom, idHom, compose } from "../GrpCat";
 import { injectiveOn, surjectiveTo, approxEq } from "../HomHelpers";
 import { parityHom, Z_to_Q, R_to_Cstar_expix } from "../homs/Examples24";
 import { FiniteGroup } from "../Group";
@@ -16,18 +16,18 @@ describe("Theorem 2 (Grp homs form a category)", () => {
     const h = hom(Z2, Z2, x => x); // id
 
     // (1) closure under composition
-    const g_of_f = comp(f,g);
+    const g_of_f = compose(f,g);
     for (const x of Z6.elems) expect(Z2.eq(g_of_f.f(x), (x%3)%2)).toBe(true);
 
     // (2) associativity
-    const left  = comp(g_of_f, h);     // h ∘ (g ∘ f)
-    const right = comp(f, comp(g,h));  // (h ∘ g) ∘ f
+    const left  = compose(g_of_f, h);     // h ∘ (g ∘ f)
+    const right = compose(f, compose(g,h));  // (h ∘ g) ∘ f
     for (const x of Z6.elems) expect(Z2.eq(left.f(x), right.f(x))).toBe(true);
 
     // (3) identities
     const idZ6 = idHom(Z6), idZ3 = idHom(Z3);
-    const f1 = comp(idZ6, f);
-    const f2 = comp(f, idZ3);
+    const f1 = compose(idZ6, f);
+    const f2 = compose(f, idZ3);
     for (const x of Z6.elems) expect(Z3.eq(f1.f(x), f.f(x))).toBe(true);
     for (const x of Z6.elems) expect(Z3.eq(f2.f(x), f.f(x))).toBe(true);
   });

--- a/src/structures/group/builders/Product.ts
+++ b/src/structures/group/builders/Product.ts
@@ -1,5 +1,6 @@
 import { FiniteGroup } from "../Group";
-import { PairingScheme, eqFromScheme } from "../pairing/PairingScheme";
+import { PairingScheme, eqFromScheme, arrayTupleScheme } from "../pairing/PairingScheme";
+import { GroupHom, hom } from "../Hom";
 
 /** Cartesian product G×H using an arbitrary pairing scheme O. */
 export function productGroup<A, B, O>(
@@ -22,4 +23,38 @@ export function productGroup<A, B, O>(
   const inv = (o: O): O => S.pair(G.inv(S.left(o)), H.inv(S.right(o)));
 
   return { elems, eq, op, id, inv };
+}
+
+/** Simple tuple-based product G×H = FiniteGroup<[A, B]>. */
+export function productGroupTuples<A, B>(
+  G: FiniteGroup<A>, 
+  H: FiniteGroup<B>
+): FiniteGroup<[A, B]> {
+  return productGroup(G, H, arrayTupleScheme());
+}
+
+/** Projection π1: G × H → G */
+export function proj1<A, B>(G: FiniteGroup<A>, H: FiniteGroup<B>): GroupHom<[A, B], A> {
+  return hom(productGroupTuples(G, H), G, ([a, b]) => a, () => true);
+}
+
+/** Projection π2: G × H → H */
+export function proj2<A, B>(G: FiniteGroup<A>, H: FiniteGroup<B>): GroupHom<[A, B], B> {
+  return hom(productGroupTuples(G, H), H, ([a, b]) => b, () => true);
+}
+
+/** Pair into product: K → G × H given K → G and K → H */
+export function pairIntoProduct<K, A, B>(
+  K: FiniteGroup<K>,
+  G: FiniteGroup<A>,
+  H: FiniteGroup<B>,
+  u: GroupHom<K, A>,
+  v: GroupHom<K, B>
+): GroupHom<K, [A, B]> {
+  return hom(
+    K,
+    productGroupTuples(G, H),
+    (k) => [u.f(k), v.f(k)],
+    () => (u.verify?.() ?? true) && (v.verify?.() ?? true)
+  );
 }

--- a/src/structures/group/builders/ProductUP.ts
+++ b/src/structures/group/builders/ProductUP.ts
@@ -1,5 +1,5 @@
 import { FiniteGroup } from "../Group";
-import { GroupHom, hom } from "../GrpCat";
+import { GroupHom, hom } from "../Hom";
 import { PairingScheme } from "../pairing/PairingScheme";
 
 /** Projections π1, π2 : G×H → G,H for a chosen pairing scheme. */

--- a/src/structures/group/cat/GroupCat.ts
+++ b/src/structures/group/cat/GroupCat.ts
@@ -6,9 +6,12 @@ export function id<A>(Obj: GroupHom<A, A>["source"]): GroupHom<A, A> {
 }
 
 /** Composition g ∘ f. Types ensure target/source match. */
-export function comp<A, B, C>(f: GroupHom<A, B>, g: GroupHom<B, C>): GroupHom<A, C> {
+export function compose<A, B, C>(f: GroupHom<A, B>, g: GroupHom<B, C>): GroupHom<A, C> {
   return hom(f.source, g.target, (a: A) => g.f(f.f(a)), () => true);
 }
+
+// Back-compat alias (TODO deprecate and remove after callers are migrated)
+export const comp = compose;
 
 /** Extensional equality of homs on a finite source. */
 export function homEqByPoints<A, B>(h1: GroupHom<A, B>, h2: GroupHom<A, B>): boolean {

--- a/src/structures/group/iso/GroupIso.ts
+++ b/src/structures/group/iso/GroupIso.ts
@@ -2,7 +2,7 @@
 // We store BOTH directions so composition and inverses are trivial.
 
 import { GroupHom } from "../GrpCat";
-import { homEqByPoints, comp, id } from "../cat/GroupCat";
+import { homEqByPoints, compose, id } from "../cat/GroupCat";
 import { FiniteGroup } from "../Group";
 
 export type GroupIso<A, B> = {
@@ -19,8 +19,8 @@ export function isoId<A>(G: FiniteGroup<A>): GroupIso<A, A> {
 // Compose B⟶C with A⟶B to get A⟶C
 export function isoComp<A, B, C>(ab: GroupIso<A, B>, bc: GroupIso<B, C>): GroupIso<A, C> {
   return {
-    forward: comp(ab.forward, bc.forward),
-    backward: comp(bc.backward, ab.backward),
+    forward: compose(ab.forward, bc.forward),
+    backward: compose(bc.backward, ab.backward),
   };
 }
 

--- a/src/structures/group/pairing/PairingScheme.ts
+++ b/src/structures/group/pairing/PairingScheme.ts
@@ -25,6 +25,15 @@ export function tupleScheme<A, B>(): PairingScheme<A, B, { a: A; b: B }> {
   };
 }
 
+/** Array tuple scheme for [A, B] pairs. */
+export function arrayTupleScheme<A, B>(): PairingScheme<A, B, [A, B]> {
+  return {
+    pair: (a, b) => [a, b],
+    left: (o) => o[0],
+    right: (o) => o[1]
+  };
+}
+
 /** Index-based numeric scheme for finite carriers (shows "representation independence"). */
 export function indexScheme<A, B>(
   Aelems: A[],

--- a/src/structures/ring/Ring.ts
+++ b/src/structures/ring/Ring.ts
@@ -1,9 +1,9 @@
 // Finite rings (possibly noncommutative). Morphisms live in RingHom.ts.
-export type Eq<A> = (x:A,y:A)=>boolean;
+export type RingEq<A> = (x:A,y:A)=>boolean;
 
 export type FiniteRing<A> = {
   elems: A[];
-  eq: Eq<A>;
+  eq: RingEq<A>;
 
   // additive abelian group
   add: (a:A,b:A)=>A;


### PR DESCRIPTION
Rename `Eq` to `RingEq` in `structures/ring/Ring.ts` to resolve a name collision with `category/Eq.ts`.

---
<a href="https://cursor.com/background-agent?bcId=bc-6b89c9a3-788a-4e95-85f2-effe126e5082">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6b89c9a3-788a-4e95-85f2-effe126e5082">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

