### PR TITLE
Check for new isomorphism files

### DIFF
--- a/src/algebra/group/finite/Dihedral.ts
+++ b/src/algebra/group/finite/Dihedral.ts
@@ -1,0 +1,34 @@
+// Dihedral.ts
+// Finite dihedral group D_n of order 2n: symmetries of a regular n-gon.
+// Elements encoded as pairs (i, f) where i in 0..n-1 is rotation power r^i,
+// and f in {0,1} marks flip (0=no flip, 1=flip).
+// Multiplication rules (with i,j mod n):
+//   (i,0)·(j,0) = (i+j, 0)
+//   (i,0)·(j,1) = (i+j, 1)
+//   (i,1)·(j,0) = (i-j, 1)
+//   (i,1)·(j,1) = (i-j, 0)
+
+import type { CayleyTable } from "../iso/CanonicalTable";
+
+export function Dn(n: number): CayleyTable {
+  if (n < 3) throw new Error("Dn requires n>=3");
+  const N = 2 * n;
+  const idx = (i: number, f: number) => i + (f ? n : 0); // pack (i,f) -> 0..2n-1
+  const unpack = (a: number) => (a < n ? [a, 0] as const : [a - n, 1] as const);
+
+  const t: CayleyTable = Array.from({ length: N }, () => Array(N).fill(0));
+
+  for (let a = 0; a < N; a++) for (let b = 0; b < N; b++) {
+    const [i, fa] = unpack(a);
+    const [j, fb] = unpack(b);
+
+    let k: number, f: number;
+    if (fa === 0 && fb === 0) { k = (i + j) % n; f = 0; }
+    else if (fa === 0 && fb === 1) { k = (i + j) % n; f = 1; }
+    else if (fa === 1 && fb === 0) { k = (i - j + n) % n; f = 1; }
+    else /* fa=1, fb=1 */      { k = (i - j + n) % n; f = 0; }
+
+    t[a][b] = idx(k, f);
+  }
+  return t;
+}

--- a/test/finite/dihedral.test.ts
+++ b/test/finite/dihedral.test.ts
@@ -1,0 +1,29 @@
+import { Dn } from "../../src/algebra/group/finite/Dihedral";
+import { isLatinSquare } from "../../src/algebra/group/iso/CanonicalTable";
+
+describe("Dn", () => {
+  it("D4 has size 8 and basic relations", () => {
+    const t = Dn(4);
+    expect(t.length).toBe(8);
+    expect(isLatinSquare(t)).toBe(true);
+
+    // identity should be (0,0) = index 0
+    const e = 0;
+    for (let a = 0; a < 8; a++) {
+      expect(t[e][a]).toBe(a);
+      expect(t[a][e]).toBe(a);
+    }
+
+    // r = (1,0) has order 4; s = (0,1) has order 2; s r s = r^{-1}
+    const r = 1, s = 4; // because (i,f) pack: (1,0)->1 ; (0,1)->4
+    // r^4 = e
+    let x = r;
+    for (let i = 0; i < 3; i++) x = t[x][r];
+    expect(x).toBe(e);
+    // s^2 = e
+    expect(t[s][s]).toBe(e);
+    // s r s = r^{-1} = r^3
+    const rinv = 3; // r^3
+    expect(t[t[s][r]][s]).toBe(rinv);
+  });
+});

--- a/test/iso/iso_class.test.ts
+++ b/test/iso/iso_class.test.ts
@@ -1,0 +1,20 @@
+import { IsoClass } from "../../src/algebra/group/iso/IsoClass";
+import { V4, Cn } from "../../src/algebra/group/finite/StandardGroups";
+
+describe("IsoClass: Klein four examples", () => {
+  it("V4 vs another V4 presentation are equal up to relabeling", () => {
+    const v4a = new IsoClass(V4());
+    // Make a relabeled copy by swapping element names (0 1 2 3) -> (0 2 1 3)
+    const t = V4();
+    const p = [0,2,1,3];
+    const t2 = t.map((row, i) => p.map((_, j) => p[t[p.indexOf(i)][p.indexOf(j)]]));
+    const v4b = new IsoClass(t2);
+    expect(v4a.equals(v4b)).toBe(true);
+  });
+
+  it("C4 is not isomorphic to V4 (different canonical keys)", () => {
+    const c4 = new IsoClass(Cn(4));
+    const v4 = new IsoClass(V4());
+    expect(c4.equals(v4)).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
     include: [
       'src/**/*.test.ts',
       'src/**/__tests__/**/*.test.ts',
-      'tests/**/*.test.ts'
+      'tests/**/*.test.ts',
+      'test/**/*.test.ts'
     ],
     exclude: [
       'node_modules',


### PR DESCRIPTION
Add Dihedral group `Dn(n)` constructor and tests, and complete the `IsoClass` test file.

This PR introduces the `Dn(n)` finite group, representing symmetries of an n-gon, expanding the library's collection of standard groups. It also addresses a previously identified missing test file for `IsoClass` examples, ensuring comprehensive test coverage for isomorphism classification. The `vitest` configuration was updated to correctly discover the new test files.

---
<a href="https://cursor.com/background-agent?bcId=bc-5254519e-8435-46c8-9414-9d9dcc1ef74e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5254519e-8435-46c8-9414-9d9dcc1ef74e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

